### PR TITLE
[FEAT] Kakao Map API를 이용해 좌표 - 법정동 코드 변환 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
+    // Feign Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.0'
 
     // JWT
     implementation 'com.auth0:java-jwt:4.4.0'

--- a/src/main/java/io/oeid/mogakgo/MogakGoApplication.java
+++ b/src/main/java/io/oeid/mogakgo/MogakGoApplication.java
@@ -2,8 +2,10 @@ package io.oeid.mogakgo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class MogakGoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/io/oeid/mogakgo/core/properties/KakaoProperties.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/KakaoProperties.java
@@ -1,0 +1,19 @@
+package io.oeid.mogakgo.core.properties;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "kakao")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoProperties {
+
+    private String prefix;
+    private String restApiKey;
+}

--- a/src/main/java/io/oeid/mogakgo/domain/geo/application/GeoService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/geo/application/GeoService.java
@@ -15,6 +15,11 @@ public class GeoService {
     private final KakaoFeignClient kakaoFeignClient;
     private final KakaoProperties kakaoProperties;
 
+    public int getAreaCodeAboutCoordinates(Double x, Double y) {
+        AddressDocument document = getAddressInfoAboutAreaCode(x, y);
+        return extractAreaCode(document);
+    }
+
     public AddressDocument getAddressInfoAboutAreaCode(Double x, Double y) {
         String key = generateKey(kakaoProperties);
         AddressInfoDto response = kakaoFeignClient.getAreaCodeAboutCoordinates(key, x, y);
@@ -25,7 +30,7 @@ public class GeoService {
         return kakaoProperties.getPrefix() + SEPERATOR + kakaoProperties.getRestApiKey();
     }
 
-    public int extractAreaCode(AddressDocument document) {
+    private int extractAreaCode(AddressDocument document) {
         return Integer.parseInt(document.getCode().substring(0, 5));
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/geo/application/GeoService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/geo/application/GeoService.java
@@ -1,0 +1,31 @@
+package io.oeid.mogakgo.domain.geo.application;
+
+import io.oeid.mogakgo.core.properties.KakaoProperties;
+import io.oeid.mogakgo.domain.geo.feign.KakaoFeignClient;
+import io.oeid.mogakgo.domain.geo.feign.dto.AddressDocument;
+import io.oeid.mogakgo.domain.geo.feign.dto.AddressInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GeoService {
+
+    private static final String SEPERATOR = " ";
+    private final KakaoFeignClient kakaoFeignClient;
+    private final KakaoProperties kakaoProperties;
+
+    public AddressDocument getAddressInfoAboutAreaCode(Double x, Double y) {
+        String key = generateKey(kakaoProperties);
+        AddressInfoDto response = kakaoFeignClient.getAreaCodeAboutCoordinates(key, x, y);
+        return response.getDocuments()[0];
+    }
+
+    private String generateKey(KakaoProperties kakaoProperties) {
+        return kakaoProperties.getPrefix() + SEPERATOR + kakaoProperties.getRestApiKey();
+    }
+
+    public int extractAreaCode(AddressDocument document) {
+        return Integer.parseInt(document.getCode().substring(0, 5));
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/geo/feign/KakaoFeignClient.java
+++ b/src/main/java/io/oeid/mogakgo/domain/geo/feign/KakaoFeignClient.java
@@ -1,0 +1,21 @@
+package io.oeid.mogakgo.domain.geo.feign;
+
+import io.oeid.mogakgo.domain.geo.feign.dto.AddressInfoDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "kakaoFeignClient",
+    url = "https://dapi.kakao.com/v2/local/geo/coord2regioncode.json"
+)
+public interface KakaoFeignClient {
+
+    @GetMapping
+    AddressInfoDto getAreaCodeAboutCoordinates(
+        @RequestHeader("Authorization") String token,
+        @RequestParam("x") Double x, @RequestParam("y") Double y
+        // x: longitude (위도), y: latitude (경도)
+    );
+}

--- a/src/main/java/io/oeid/mogakgo/domain/geo/feign/dto/AddressDocument.java
+++ b/src/main/java/io/oeid/mogakgo/domain/geo/feign/dto/AddressDocument.java
@@ -1,0 +1,16 @@
+package io.oeid.mogakgo.domain.geo.feign.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AddressDocument {
+
+    private Character regionType;
+    private String code;
+    private String addressName;
+    private double x; // longitude
+    private double y; // latitude
+}

--- a/src/main/java/io/oeid/mogakgo/domain/geo/feign/dto/AddressInfoDto.java
+++ b/src/main/java/io/oeid/mogakgo/domain/geo/feign/dto/AddressInfoDto.java
@@ -1,0 +1,9 @@
+package io.oeid.mogakgo.domain.geo.feign.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AddressInfoDto {
+
+    private AddressDocument[] documents;
+}


### PR DESCRIPTION
## 🚀 개발 사항
Kakao Map API를 OpenFeign 라이브러리를 이용해서 호출하고, 쿼리 파라미터로 입력한 좌표에 대한 '구' 법정동 코드를 추출하는 메서드 구현
- [x] 좌표 `x`, `y` (위도, 경도)에 대한 '구' 법정동 코드를 가져옴
  `getAreaCodeAboutCoordinates()`

- [x] Kakao Map API를 호출해서 응답을 가져옴
  `getAddressInfoAboutAreaCode()`

- [x] API 호출을 위한 Key 생성함
   `generateKey()`

- [x] 응답에서 '구'에 대한 법정동 코드를 추출함
   `extractAreaCode()`  

### 이슈 번호
- close #56 

## 특이 사항 🫶 
- 외부 API를 호출하는 라이브러리를 RestTemplate을 사용하려다가 Feign Client로 외부 API를 호출하는 방식이 훨씬 가독성과 사용 측면에서 깔끔하다고 판단해서 사용해보았습니다. 참고할만한 레퍼런스를 같이 올려놓을게요!

[참고자료1](https://vmpo.tistory.com/109)
[참고자료2](https://jie0025.tistory.com/531)
