### PR TITLE
[FIX] 매칭 기록 삭제에 대한 상태 유효성 검증 추가

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
@@ -55,6 +55,13 @@ public interface ProjectSwagger {
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "204", description = "프로젝트 카드 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트를 삭제 할 수 없습니다.",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(name = "E030106", value = SwaggerProjectErrorExamples.PROJECT_DELETION_NOT_ALLOWED)
+                })),
         @ApiResponse(responseCode = "404", description = "요청한 데이터가 존재하지 않음",
             content = @Content(
                 mediaType = "application/json",

--- a/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerProjectErrorExamples.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerProjectErrorExamples.java
@@ -9,6 +9,7 @@ public class SwaggerProjectErrorExamples {
     public static final String INVALID_PROJECT_MEET_LOCATION = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E030105\",\"message\":\"프로젝트 만남 장소가 유저가 동네인증 한 구역이 아닙니다.\"}";
     public static final String PROJECT_NOT_FOUND = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":404,\"code\":\"E030301\",\"message\":\"해당 프로젝트가 존재하지 않습니다.\"}";
     public static final String PROJECT_FORBIDDEN_OPERATION = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":403,\"code\":\"E030201\",\"message\":\"해당 프로젝트에 대한 권한이 없습니다.\"}";
+    public static final String PROJECT_DELETION_NOT_ALLOWED = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E030106\",\"message\":\"매칭 중이거나 대기중인 프로젝트는 삭제할 수 없습니다.\"}";
     private SwaggerProjectErrorExamples() {
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/project/domain/entity/Project.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/domain/entity/Project.java
@@ -80,8 +80,13 @@ public class Project extends BaseTimeEntity {
     }
 
     public void delete(User tokenUser) {
-        validateCreator(tokenUser);
+        validateAvailableDelete(tokenUser);
         super.delete();
+    }
+
+    private void validateAvailableDelete(User tokenUser) {
+        validateCreator(tokenUser);
+        this.projectStatus.validateAvailableDelete();
     }
 
     private void validateCreator(User tokenUser) {

--- a/src/main/java/io/oeid/mogakgo/domain/project/domain/entity/enums/ProjectStatus.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/domain/entity/enums/ProjectStatus.java
@@ -1,16 +1,26 @@
 package io.oeid.mogakgo.domain.project.domain.entity.enums;
 
+import static io.oeid.mogakgo.exception.code.ErrorCode400.PROJECT_DELETION_NOT_ALLOWED;
+
+import io.oeid.mogakgo.domain.project.exception.ProjectException;
 import lombok.Getter;
 
 @Getter
 public enum ProjectStatus {
     PENDING("매칭 대기중"),
     MATCHED("매칭 완료됨"),
-    CANCELED("매칭 취소됨");
+    CANCELED("매칭 취소됨"),
+    FINISHED("매칭 종료됨");
 
     private final String description;
 
     ProjectStatus(String description) {
         this.description = description;
+    }
+
+    public void validateAvailableDelete() {
+        if (this == PENDING || this == MATCHED) {
+            throw new ProjectException(PROJECT_DELETION_NOT_ALLOWED);
+        }
     }
 }

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
@@ -17,6 +17,8 @@ public enum ErrorCode400 implements ErrorCode {
         "프로젝트 태그 내용 길이가 유효하지 않습니다. 1자 이상 7자 이하로 입력해야 합니다."),
     INVALID_PROJECT_NULL_DATA("E030104", "프로젝트를 생성하기 위해 null 이여서는 안되는 데이터가 null 입니다."),
     NOT_MATCH_MEET_LOCATION("E030105", "프로젝트 만남 장소가 유저가 동네인증 한 구역이 아닙니다."),
+    PROJECT_DELETION_NOT_ALLOWED("E030106", "매칭 중이거나 대기중인 프로젝트는 삭제할 수 없습니다."),
+
     USER_DEVELOP_LANGUAGE_BAD_REQUEST("E020101", "개발 언어는 3개까지만 등록 가능합니다."),
     USER_WANTED_JOB_BAD_REQUEST("E020102", "희망 직무는 3개까지만 등록 가능합니다."),
     USERNAME_SHOULD_BE_NOT_EMPTY("E020103", "유저 이름은 비어있을 수 없습니다."),


### PR DESCRIPTION
## 🚀 개발 사항
매칭 기록 삭제에 대한 상태 유효성 검증 추가

### 이슈 번호
- close #70 

## 특이 사항 🫶 
