### PR TITLE
[FEAT] 프로젝트 참가 요청 조회 기능 구현

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationInfoReq.java
+++ b/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationInfoReq.java
@@ -1,0 +1,27 @@
+package io.oeid.mogakgo.common.base;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.lang.Nullable;
+
+@Getter
+public class CursorPaginationInfoReq {
+
+    @Nullable
+    private final Long cursorId;
+
+    @NotNull
+    private final int pageSize;
+
+    @Nullable
+    private final Sort.Direction sortOrder;
+
+    public CursorPaginationInfoReq(Long cursorId, int pageSize, Direction sortOrder) {
+        this.cursorId = cursorId;
+        this.pageSize = pageSize;
+        this.sortOrder = Objects.requireNonNullElse(sortOrder, Direction.ASC);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationResult.java
+++ b/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationResult.java
@@ -1,0 +1,50 @@
+package io.oeid.mogakgo.common.base;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+
+@Schema(description = "커서 기반 페이지네이션 결과에 대한 일괄 응답")
+@Getter
+public class CursorPaginationResult<T> {
+
+    @Schema(description = "데이터 목록")
+    private List<T> data;
+    @Schema(description = "다음 페이지가 있는지 여부")
+    private boolean hasNext;
+    @Schema(description = "현재 페이지의 데이터 수")
+    private Integer numberOfElements;
+    @Schema(description = "요청한 데이터 수")
+    private Integer size;
+
+    private CursorPaginationResult(List<T> data, Integer size) {
+        this.data = data;
+        this.size = size;
+        if (data.size() > size) {
+            this.hasNext = true;
+            this.data.remove(data.size() - 1);
+        } else {
+            this.hasNext = false;
+        }
+        this.numberOfElements = data.size();
+    }
+
+    private CursorPaginationResult(List<T> data, Integer size, boolean hasNext) {
+        this.data = data;
+        this.numberOfElements = data.size();
+        this.hasNext = hasNext;
+        this.size = size;
+    }
+
+    public static <T> CursorPaginationResult<T> fromDataWithExtraItemForNextCheck(
+        List<T> data, Integer size
+    ) {
+        return new CursorPaginationResult<>(data, size);
+    }
+
+    public static <T> CursorPaginationResult<T> fromDataWithHasNext(
+        List<T> data, Integer size, boolean hasNext
+    ) {
+        return new CursorPaginationResult<>(data, size, hasNext);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
@@ -1,12 +1,16 @@
 package io.oeid.mogakgo.common.swagger.template;
 
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerProjectErrorExamples;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerUserErrorExamples;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectIdRes;
+import io.oeid.mogakgo.domain.project_join_req.presentation.projectJoinRequestRes;
 import io.oeid.mogakgo.exception.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -106,5 +110,33 @@ public interface ProjectSwagger {
     ResponseEntity<ProjectIdRes> cancel(
         @Parameter(hidden = true) Long userId,
         @Parameter(description = "프로젝트 ID", required = true) Long id
+    );
+
+    @Operation(summary = "프로젝트 카드 참가 요청 조회", description = "회원이 프로젝트 카드의 참가 요청을 조회할 때 사용하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "프로젝트 카드 참가 요청 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "요청한 데이터가 존재하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(name = "E030301", value = SwaggerProjectErrorExamples.PROJECT_NOT_FOUND),
+                    @ExampleObject(name = "E020301", value = SwaggerUserErrorExamples.USER_NOT_FOUND)
+                })),
+        @ApiResponse(responseCode = "403", description = "본인의 프로젝트 카드만 조회 할 수 있음.",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E050201", value = SwaggerProjectErrorExamples.PROJECT_JOIN_REQUEST_FORBIDDEN_OPERATION)))
+    })
+    @Parameters({
+        @Parameter(name = "cursorId", description = "기준이 되는 커서 ID", example = "1"),
+        @Parameter(name = "pageSize", description = "요청할 데이터 크기", example = "5", required = true),
+        @Parameter(name = "sortOrder", description = "정렬 방향", example = "ASC"),
+    })
+    ResponseEntity<CursorPaginationResult<projectJoinRequestRes>> getJoinRequest(
+        @Parameter(hidden = true) Long userId,
+        @Parameter(description = "프로젝트 ID", required = true) Long id,
+        @Parameter(hidden = true) CursorPaginationInfoReq pageable
     );
 }

--- a/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerProjectErrorExamples.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerProjectErrorExamples.java
@@ -11,6 +11,7 @@ public class SwaggerProjectErrorExamples {
     public static final String PROJECT_FORBIDDEN_OPERATION = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":403,\"code\":\"E030201\",\"message\":\"해당 프로젝트에 대한 권한이 없습니다.\"}";
     public static final String PROJECT_DELETION_NOT_ALLOWED = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E030106\",\"message\":\"매칭 중이거나 대기중인 프로젝트는 삭제할 수 없습니다.\"}";
     public static final String PROJECT_CANCEL_NOT_ALLOWED = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E030107\",\"message\":\"이미 취소 되었거나 종료된 프로젝트는 취소할 수 없습니다.\"}";
+    public static final String PROJECT_JOIN_REQUEST_FORBIDDEN_OPERATION = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":403,\"code\":\"E050201\",\"message\":\"해당 프로젝트 요청에 대한 권한이 없습니다.\"}";
     private SwaggerProjectErrorExamples() {
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
@@ -2,16 +2,21 @@ package io.oeid.mogakgo.domain.project.application;
 
 import static io.oeid.mogakgo.exception.code.ErrorCode400.NOT_MATCH_MEET_LOCATION;
 import static io.oeid.mogakgo.exception.code.ErrorCode403.PROJECT_FORBIDDEN_OPERATION;
+import static io.oeid.mogakgo.exception.code.ErrorCode403.PROJECT_JOIN_REQUEST_FORBIDDEN_OPERATION;
 import static io.oeid.mogakgo.exception.code.ErrorCode404.PROJECT_NOT_FOUND;
 import static io.oeid.mogakgo.exception.code.ErrorCode404.USER_NOT_FOUND;
 
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.application.GeoService;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
 import io.oeid.mogakgo.domain.project.domain.entity.Project;
 import io.oeid.mogakgo.domain.project.exception.ProjectException;
 import io.oeid.mogakgo.domain.project.infrastructure.ProjectJpaRepository;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
+import io.oeid.mogakgo.domain.project_join_req.exception.ProjectJoinRequestException;
 import io.oeid.mogakgo.domain.project_join_req.infrastruture.ProjectJoinRequestJpaRepository;
+import io.oeid.mogakgo.domain.project_join_req.presentation.projectJoinRequestRes;
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.domain.user.exception.UserException;
 import io.oeid.mogakgo.domain.user.infrastructure.UserJpaRepository;
@@ -71,6 +76,28 @@ public class ProjectService {
 
         // 프로젝트 취소
         project.cancel(user, projectHasReq);
+    }
+
+    public CursorPaginationResult<projectJoinRequestRes> getJoinRequest(
+        Long userId, Long projectId, CursorPaginationInfoReq pageable
+    ) {
+        // 유저 존재 여부 체크
+        User user = getUser(userId);
+
+        // 프로젝트 존재 여부 체크
+        Project project = getProject(projectId);
+
+        // 본인만 본인의 프로젝트 참가 요청을 조회할 수 있음
+        // TODO : project exception 인지 project join request exception 인지 확인
+        try {
+            project.validateCreator(user);
+        } catch (ProjectException e) {
+            throw new ProjectJoinRequestException(PROJECT_JOIN_REQUEST_FORBIDDEN_OPERATION);
+        }
+
+        // 프로젝트 참가 요청 조회
+        return projectJoinRequestJpaRepository.findByConditionWithPagination(
+            null, projectId, null, null);
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/io/oeid/mogakgo/domain/project/domain/entity/Project.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/domain/entity/Project.java
@@ -93,6 +93,12 @@ public class Project extends BaseTimeEntity {
         this.projectStatus = ProjectStatus.CANCELED;
     }
 
+    public void validateCreator(User tokenUser) {
+        if (tokenUser == null || !this.creator.getId().equals(tokenUser.getId())) {
+            throw new ProjectException(PROJECT_FORBIDDEN_OPERATION);
+        }
+    }
+
     private void validateAvailableCancel(User tokenUser) {
         validateCreator(tokenUser);
         this.projectStatus.validateAvailableCancel();
@@ -101,12 +107,6 @@ public class Project extends BaseTimeEntity {
     private void validateAvailableDelete(User tokenUser) {
         validateCreator(tokenUser);
         this.projectStatus.validateAvailableDelete();
-    }
-
-    private void validateCreator(User tokenUser) {
-        if (tokenUser == null || !this.creator.getId().equals(tokenUser.getId())) {
-            throw new ProjectException(PROJECT_FORBIDDEN_OPERATION);
-        }
     }
 
     private void addProjectTagsWithValidation(List<ProjectTagCreateReq> projectTags) {

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
@@ -1,14 +1,19 @@
 package io.oeid.mogakgo.domain.project.presentation;
 
 import io.oeid.mogakgo.common.annotation.UserId;
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.common.swagger.template.ProjectSwagger;
 import io.oeid.mogakgo.domain.project.application.ProjectService;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectIdRes;
+import io.oeid.mogakgo.domain.project_join_req.presentation.projectJoinRequestRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,6 +50,14 @@ public class ProjectController implements ProjectSwagger {
     ) {
         projectService.cancel(userId, id);
         return ResponseEntity.status(200).body(ProjectIdRes.from(id));
+    }
+
+    @GetMapping("/{id}/requests")
+    public ResponseEntity<CursorPaginationResult<projectJoinRequestRes>> getJoinRequest(
+        @UserId Long userId, @PathVariable Long id,
+        @Valid @ModelAttribute CursorPaginationInfoReq pageable
+    ) {
+        return ResponseEntity.ok().body(projectService.getJoinRequest(userId, id, pageable));
     }
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/req/ProjectCreateReq.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/req/ProjectCreateReq.java
@@ -10,7 +10,6 @@ import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PastOrPresent;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
@@ -53,7 +52,7 @@ public class ProjectCreateReq {
     @NotBlank
     private String meetDetail;
 
-    @Schema(description = "프로젝트 태그 목록", implementation = ProjectTagCreateReq.class,
+    @Schema(description = "프로젝트 태그 목록",
         example = "[{\"content\":\"인싸\"},{\"content\":\"말많은\"}]")
     @NotEmpty
     private List<@Valid ProjectTagCreateReq> tags;

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/exception/ProjectJoinRequestException.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/exception/ProjectJoinRequestException.java
@@ -1,0 +1,11 @@
+package io.oeid.mogakgo.domain.project_join_req.exception;
+
+import io.oeid.mogakgo.exception.code.ErrorCode;
+import io.oeid.mogakgo.exception.exception_class.CustomException;
+
+public class ProjectJoinRequestException extends CustomException {
+
+    public ProjectJoinRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastruture/ProjectJoinRequestJpaRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastruture/ProjectJoinRequestJpaRepository.java
@@ -3,7 +3,8 @@ package io.oeid.mogakgo.domain.project_join_req.infrastruture;
 import io.oeid.mogakgo.domain.project_join_req.domain.entity.ProjectJoinRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectJoinRequestJpaRepository extends JpaRepository<ProjectJoinRequest, Long> {
+public interface ProjectJoinRequestJpaRepository extends JpaRepository<ProjectJoinRequest, Long>,
+    ProjectJoinRequestRepositoryCustom {
 
     boolean existsByProjectId(Long projectId);
 

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastruture/ProjectJoinRequestRepositoryCustom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastruture/ProjectJoinRequestRepositoryCustom.java
@@ -1,0 +1,14 @@
+package io.oeid.mogakgo.domain.project_join_req.infrastruture;
+
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
+import io.oeid.mogakgo.domain.project_join_req.domain.entity.enums.RequestStatus;
+import io.oeid.mogakgo.domain.project_join_req.presentation.projectJoinRequestRes;
+
+public interface ProjectJoinRequestRepositoryCustom {
+
+    CursorPaginationResult<projectJoinRequestRes> findByConditionWithPagination(
+        Long senderId, Long projectId, RequestStatus requestStatus, CursorPaginationInfoReq pageable
+    );
+
+}

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastruture/ProjectJoinRequestRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastruture/ProjectJoinRequestRepositoryCustomImpl.java
@@ -1,0 +1,71 @@
+package io.oeid.mogakgo.domain.project_join_req.infrastruture;
+
+import static io.oeid.mogakgo.domain.project_join_req.domain.entity.QProjectJoinRequest.projectJoinRequest;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
+import io.oeid.mogakgo.domain.project_join_req.domain.entity.enums.RequestStatus;
+import io.oeid.mogakgo.domain.project_join_req.presentation.projectJoinRequestRes;
+import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPreviewRes;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectJoinRequestRepositoryCustomImpl implements ProjectJoinRequestRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public CursorPaginationResult<projectJoinRequestRes> findByConditionWithPagination(
+        Long senderId, Long projectId, RequestStatus requestStatus, CursorPaginationInfoReq pageable
+    ) {
+        List<projectJoinRequestRes> result = jpaQueryFactory.select(
+                Projections.constructor(
+                    projectJoinRequestRes.class,
+                    projectJoinRequest.id,
+                    Projections.constructor(
+                        UserPreviewRes.class,
+                        projectJoinRequest.sender.id,
+                        projectJoinRequest.sender.username,
+                        projectJoinRequest.sender.avatarUrl
+                    ),
+                    projectJoinRequest.requestStatus
+                )
+            )
+            .from(projectJoinRequest)
+            .join(projectJoinRequest.sender)
+            .where(
+                cursorIdCondition(pageable.getCursorId()),
+                senderIdEq(senderId),
+                projectIdEq(projectId),
+                requestStatusEq(requestStatus)
+            )
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return CursorPaginationResult.fromDataWithExtraItemForNextCheck(result,
+            pageable.getPageSize());
+    }
+
+    private BooleanExpression senderIdEq(Long senderId) {
+        return senderId != null ? projectJoinRequest.sender.id.eq(senderId) : null;
+    }
+
+    private BooleanExpression projectIdEq(Long projectId) {
+        return projectId != null ? projectJoinRequest.project.id.eq(projectId) : null;
+    }
+
+    private BooleanExpression requestStatusEq(RequestStatus requestStatus) {
+        return requestStatus != null ? projectJoinRequest.requestStatus.eq(requestStatus) : null;
+    }
+
+    private BooleanExpression cursorIdCondition(Long cursorId) {
+        return cursorId != null ? projectJoinRequest.id.gt(cursorId) : null;
+    }
+
+}

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/projectJoinRequestRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/projectJoinRequestRes.java
@@ -1,0 +1,26 @@
+package io.oeid.mogakgo.domain.project_join_req.presentation;
+
+import io.oeid.mogakgo.domain.project_join_req.domain.entity.enums.RequestStatus;
+import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPreviewRes;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "프로젝트 요청 응답 DTO")
+@Getter
+public class projectJoinRequestRes {
+
+    @Schema(description = "프로젝트 요청 ID")
+    private Long id;
+    @Schema(description = "요청자 정보 미리보기")
+    private UserPreviewRes senderPreview;
+    @Schema(description = "요청 상태")
+    private RequestStatus requestStatus;
+
+    public projectJoinRequestRes(
+        Long id, UserPreviewRes senderPreview, RequestStatus requestStatus
+    ) {
+        this.id = id;
+        this.senderPreview = senderPreview;
+        this.requestStatus = requestStatus;
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserPreviewRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserPreviewRes.java
@@ -1,0 +1,21 @@
+package io.oeid.mogakgo.domain.user.presentation.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 정보 미리보기 응답 DTO")
+public class UserPreviewRes {
+
+    private Long id;
+    private String username;
+    private String avatarUrl;
+
+    public UserPreviewRes(Long id, String username, String avatarUrl) {
+        this.id = id;
+        this.username = username;
+        this.avatarUrl = avatarUrl;
+    }
+
+    public static UserPreviewRes of(Long id, String username, String avatarUrl) {
+        return new UserPreviewRes(id, username, avatarUrl);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode403.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode403.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode403 implements ErrorCode {
     PROJECT_FORBIDDEN_OPERATION("E030201", "해당 프로젝트에 대한 권한이 없습니다."),
+    PROJECT_JOIN_REQUEST_FORBIDDEN_OPERATION("E050201", "해당 프로젝트 요청에 대한 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.FORBIDDEN;


### PR DESCRIPTION
## 🚀 개발 사항
- CursorPaginationInfoReq , CursorPaginationResult<T> 를 통해 공통 페이지네이션 req, res 생성
- CursorPaginationResult 내부에서 hasNext 계산하는 로직 구현. 정적 팩토리 메서드 별로 달라짐
    - fromDataWithExtraItemForNextCheck() 를 통해 내부에서 계산
    - fromDataWithHasNext() 는 외부에서 값을 받음

### 이슈 번호
- close #33 

## 특이 사항 🫶 
- 페이지네이션 sort 관련 사항 아직 반영 X
