### PR TITLE
[FEAT] 사용자가 보낸 프로젝트 매칭 요청 리스트 조회 API 개발

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectJoinRequestSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectJoinRequestSwagger.java
@@ -1,10 +1,13 @@
 package io.oeid.mogakgo.common.swagger.template;
 
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerProjectErrorExamples;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerProjectJoinRequestErrorExamples;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerUserErrorExamples;
 import io.oeid.mogakgo.domain.project_join_req.application.dto.req.ProjectJoinCreateReq;
 import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestAPIRes;
+import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestDetailAPIRes;
 import io.oeid.mogakgo.exception.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -51,6 +54,28 @@ public interface ProjectJoinRequestSwagger {
     ResponseEntity<ProjectJoinRequestAPIRes> create(
         @Parameter(hidden = true) Long userId,
         ProjectJoinCreateReq request
+    );
+
+    @Operation(summary = "사용자의 프로젝트 요청 리스트 조회", description = "회원이 자신이 보낸 프로젝트 요청 리스트를 조회할 때 사용하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "프로젝트 요청 리스트 조회 성공",
+            content = @Content(schema = @Schema(implementation = ProjectJoinRequestDetailAPIRes.class))),
+        @ApiResponse(responseCode = "403", description = "본인의 프로젝트 요청만 조회할 수 있음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E050201",
+                    value = SwaggerProjectJoinRequestErrorExamples.PROJECT_JOIN_REQUEST_FORBIDDEN_OPERATION))),
+        @ApiResponse(responseCode = "404", description = "요청한 데이터가 존재하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E020301", value = SwaggerUserErrorExamples.USER_NOT_FOUND)))
+    })
+    ResponseEntity<CursorPaginationResult<ProjectJoinRequestDetailAPIRes>> getBySenderIdWithPagination(
+        @Parameter(hidden = true) Long userId,
+        @Parameter(description = "사용자 ID", required = true) Long id,
+        @Parameter(hidden = true) CursorPaginationInfoReq pageable
     );
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/application/ProjectJoinRequestService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/application/ProjectJoinRequestService.java
@@ -6,6 +6,8 @@ import static io.oeid.mogakgo.exception.code.ErrorCode403.PROJECT_JOIN_REQUEST_F
 import static io.oeid.mogakgo.exception.code.ErrorCode404.PROJECT_NOT_FOUND;
 import static io.oeid.mogakgo.exception.code.ErrorCode404.USER_NOT_FOUND;
 
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.project.domain.entity.Project;
 import io.oeid.mogakgo.domain.project.exception.ProjectException;
 import io.oeid.mogakgo.domain.project.infrastructure.ProjectJpaRepository;
@@ -13,6 +15,7 @@ import io.oeid.mogakgo.domain.project_join_req.application.dto.req.ProjectJoinCr
 import io.oeid.mogakgo.domain.project_join_req.domain.entity.ProjectJoinRequest;
 import io.oeid.mogakgo.domain.project_join_req.exception.ProjectJoinRequestException;
 import io.oeid.mogakgo.domain.project_join_req.infrastructure.ProjectJoinRequestJpaRepository;
+import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestDetailAPIRes;
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.domain.user.exception.UserException;
 import io.oeid.mogakgo.domain.user.infrastructure.UserJpaRepository;
@@ -40,6 +43,18 @@ public class ProjectJoinRequestService {
         projectJoinRequestRepository.save(joinRequest);
 
         return joinRequest.getId();
+    }
+
+    public CursorPaginationResult<ProjectJoinRequestDetailAPIRes> getBySenderIdWithPagination(
+        Long userId, Long senderId, CursorPaginationInfoReq pageable
+    ) {
+        User tokenUser = validateToken(userId);
+        validateSender(tokenUser, senderId);
+
+        // 사용자가 보낸 프로젝트 매칭 요청 리스트
+        return projectJoinRequestRepository.getBySenderIdWithPagination(
+            senderId, null, null, pageable
+        );
     }
 
     private User validateToken(Long userId) {

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestRepositoryCustom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestRepositoryCustom.java
@@ -3,11 +3,16 @@ package io.oeid.mogakgo.domain.project_join_req.infrastructure;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.project_join_req.domain.entity.enums.RequestStatus;
+import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestDetailAPIRes;
 import io.oeid.mogakgo.domain.project_join_req.presentation.projectJoinRequestRes;
 
 public interface ProjectJoinRequestRepositoryCustom {
 
     CursorPaginationResult<projectJoinRequestRes> findByConditionWithPagination(
+        Long senderId, Long projectId, RequestStatus requestStatus, CursorPaginationInfoReq pageable
+    );
+
+    CursorPaginationResult<ProjectJoinRequestDetailAPIRes> getBySenderIdWithPagination(
         Long senderId, Long projectId, RequestStatus requestStatus, CursorPaginationInfoReq pageable
     );
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestRepositoryCustomImpl.java
@@ -1,13 +1,17 @@
 package io.oeid.mogakgo.domain.project_join_req.infrastructure;
 
 import static io.oeid.mogakgo.domain.project_join_req.domain.entity.QProjectJoinRequest.projectJoinRequest;
+import static io.oeid.mogakgo.domain.project.domain.entity.QProject.project;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.MeetingInfoResponse;
 import io.oeid.mogakgo.domain.project_join_req.domain.entity.ProjectJoinRequest;
 import io.oeid.mogakgo.domain.project_join_req.domain.entity.enums.RequestStatus;
+import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestDetailAPIRes;
 import io.oeid.mogakgo.domain.project_join_req.presentation.projectJoinRequestRes;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -64,6 +68,38 @@ public class ProjectJoinRequestRepositoryCustomImpl implements ProjectJoinReques
 
         return CursorPaginationResult.fromDataWithExtraItemForNextCheck(result,
             pageable.getPageSize());
+    }
+
+    @Override
+    public CursorPaginationResult<ProjectJoinRequestDetailAPIRes> getBySenderIdWithPagination(
+        Long senderId, Long projectId, RequestStatus requestStatus, CursorPaginationInfoReq pageable
+    ) {
+        List<ProjectJoinRequestDetailAPIRes> result = jpaQueryFactory.select(
+            Projections.constructor(
+                ProjectJoinRequestDetailAPIRes.class,
+                projectJoinRequest.project.id,
+                projectJoinRequest.project.creator.avatarUrl,
+                Projections.constructor(
+                    MeetingInfoResponse.class,
+                    projectJoinRequest.project.meetingInfo.meetStartTime,
+                    projectJoinRequest.project.meetingInfo.meetEndTime,
+                    projectJoinRequest.project.meetingInfo.meetDetail
+                ))
+            )
+            .from(projectJoinRequest)
+            .innerJoin(project).on(projectJoinRequest.project.id.eq(projectId))
+            .where(
+                cursorIdCondition(pageable.getCursorId()),
+                senderIdEq(senderId),
+                projectIdEq(projectId),
+                requestStatusEq(requestStatus)
+            )
+            .limit(pageable.getPageSize() + 1)
+            .fetch();
+
+        return CursorPaginationResult.fromDataWithExtraItemForNextCheck(
+            result, pageable.getPageSize()
+        );
     }
 
     private BooleanExpression senderIdEq(Long senderId) {

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/ProjectJoinRequestController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/ProjectJoinRequestController.java
@@ -1,13 +1,19 @@
 package io.oeid.mogakgo.domain.project_join_req.presentation;
 
 import io.oeid.mogakgo.common.annotation.UserId;
+import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
+import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.common.swagger.template.ProjectJoinRequestSwagger;
 import io.oeid.mogakgo.domain.project_join_req.application.ProjectJoinRequestService;
 import io.oeid.mogakgo.domain.project_join_req.application.dto.req.ProjectJoinCreateReq;
 import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestAPIRes;
+import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestDetailAPIRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +32,14 @@ public class ProjectJoinRequestController implements ProjectJoinRequestSwagger {
     ) {
         return ResponseEntity.status(201)
             .body(ProjectJoinRequestAPIRes.from(projectJoinRequestService.create(userId, request)));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CursorPaginationResult<ProjectJoinRequestDetailAPIRes>> getBySenderIdWithPagination(
+        @UserId Long userId, @PathVariable Long id,
+        @Valid @ModelAttribute CursorPaginationInfoReq pageable
+    ) {
+        return ResponseEntity.ok()
+            .body(projectJoinRequestService.getBySenderIdWithPagination(userId, id, pageable));
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
@@ -1,0 +1,36 @@
+package io.oeid.mogakgo.domain.project_join_req.presentation.dto.res;
+
+import io.oeid.mogakgo.domain.project.presentation.dto.res.MeetingInfoResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Schema(description = "사용자가 보낸 프로젝트 매칭 요청 응답 DTO")
+@Getter
+public class ProjectJoinRequestDetailAPIRes {
+
+    @Schema(description = "프로젝트 ID", example = "3", implementation = Long.class)
+    @NotNull
+    private final Long projectId;
+
+    @Schema(description = "프로젝트 생성자 아바타 URL", example = "https://avatars.githubusercontent.com/u/85854384?v=4")
+    private final String creatorAvatorUrl;
+
+    @Schema(description = "프로젝트 만남 장ㅔ")
+    private final MeetingInfoResponse meetingInfo;
+
+    public ProjectJoinRequestDetailAPIRes(
+        Long projectId, String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    ) {
+        this.projectId = projectId;
+        this.creatorAvatorUrl = creatorAvatorUrl;
+        this.meetingInfo = meetingInfo;
+    }
+
+    public static ProjectJoinRequestDetailAPIRes from(
+        Long projectId, String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    ) {
+        return new ProjectJoinRequestDetailAPIRes(projectId, creatorAvatorUrl, meetingInfo);
+    }
+
+}


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자의 프로젝트 매칭 요청 리스트 조회 API
- [x] 커서 기반 페이지네이션 공통 포맷 적용
- [x] API Swagger 작성  

### 이슈 번호
- close #43 

## 특이 사항 🫶 
- 추후에 리팩토링할 예정입니다! 우선은 기능 구현에 초점을 두고 개발했습니다. 