### PR TITLE
[FEAT] 지역별 프로젝트 밀집도 랭크 조회 기능

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
@@ -1,11 +1,13 @@
 package io.oeid.mogakgo.common.swagger.template;
 
+import io.oeid.mogakgo.common.annotation.UserId;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerGeoErrorExamples;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerProjectErrorExamples;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerUserErrorExamples;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDensityRankRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectIdRes;
@@ -20,7 +22,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 
 @Tag(name = "Project Card", description = "프로젝트 카드 관련 API")
 @SuppressWarnings("unused")
@@ -171,4 +175,11 @@ public interface ProjectSwagger {
         @Parameter(description = "프로젝트 ID", required = true) Long id,
         @Parameter(hidden = true) CursorPaginationInfoReq pageable
     );
+
+    @Operation(summary = "지역별 프로젝트 밀도 순위 조회", description = "지역별 프로젝트 밀도 순위를 조회할 때 사용하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "지역별 프로젝트 밀도 순위 조회 성공",
+            content = @Content(schema = @Schema(implementation = ProjectDensityRankRes.class))),
+    })
+    ResponseEntity<ProjectDensityRankRes> getDensityRankProjects();
 }

--- a/src/main/java/io/oeid/mogakgo/domain/geo/domain/enums/Region.java
+++ b/src/main/java/io/oeid/mogakgo/domain/geo/domain/enums/Region.java
@@ -1,5 +1,6 @@
 package io.oeid.mogakgo.domain.geo.domain.enums;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -45,6 +46,14 @@ public enum Region {
             }
         }
         return null;
+    }
+
+    public static List<Region> getDefaultDensityRank() {
+        return List.of(
+            JONGRO, JUNG, YONGSAN, SEONGDONG, KWANGJIN, DONGDAEMUN, JUNGRANG, SEONGBUK, KANGBUK,
+            DOBONG, NOWON, EUNPYEONG, SEODAEMUN, MAPO, YANGCHUN, KANGSEO, GURO, GEUMCHUN,
+            YOUNGDEUNGPO, DONGJAK, KWANAK, SEOCHO, KANGNAM, SONGPA, KANGDONG
+        );
     }
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustom.java
@@ -3,12 +3,15 @@ package io.oeid.mogakgo.domain.project.infrastructure;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
-import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
 import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
+import java.util.List;
 
 public interface ProjectRepositoryCustom {
 
     CursorPaginationResult<ProjectDetailAPIRes> findByConditionWithPagination(
         Long userId, Region region, ProjectStatus projectStatus, CursorPaginationInfoReq pageable
     );
+
+    List<Region> getDensityRankProjectsByRegion(int limit);
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -72,6 +72,7 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
         return jpaQueryFactory.select(project.creatorInfo.region)
             .from(project)
             .groupBy(project.creatorInfo.region)
+            .having(project.creatorInfo.region.count().gt(0L))
             .orderBy(project.creatorInfo.region.count().desc())
             .limit(limit)
             .fetch();

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -9,9 +9,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
+import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.MeetingInfoResponse;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
-import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -65,6 +65,16 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
         return CursorPaginationResult.fromDataWithExtraItemForNextCheck(
             result, pageable.getPageSize()
         );
+    }
+
+    @Override
+    public List<Region> getDensityRankProjectsByRegion(int limit) {
+        return jpaQueryFactory.select(project.creatorInfo.region)
+            .from(project)
+            .groupBy(project.creatorInfo.region)
+            .orderBy(project.creatorInfo.region.count().desc())
+            .limit(limit)
+            .fetch();
     }
 
     private BooleanExpression cursorIdCondition(Long cursorId) {

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
@@ -6,8 +6,9 @@ import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.common.swagger.template.ProjectSwagger;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
 import io.oeid.mogakgo.domain.project.application.ProjectService;
-import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDensityRankRes;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectIdRes;
 import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.projectJoinRequestRes;
 import jakarta.validation.Valid;
@@ -70,6 +71,11 @@ public class ProjectController implements ProjectSwagger {
         return ResponseEntity.ok().body(
             projectService.getRandomOrderedProjectsByRegion(userId, region, pageable)
         );
+    }
+
+    @GetMapping("density/rank")
+    public ResponseEntity<ProjectDensityRankRes> getDensityRankProjects() {
+        return ResponseEntity.ok().body(projectService.getDensityRankProjects());
     }
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDensityRankRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDensityRankRes.java
@@ -1,0 +1,19 @@
+package io.oeid.mogakgo.domain.project.presentation.dto.res;
+
+import io.oeid.mogakgo.domain.geo.domain.enums.Region;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+
+@Schema(description = "지역별 프로젝트 밀도 순위")
+@Getter
+public class ProjectDensityRankRes {
+
+    @Schema(description = "지역별 프로젝트 밀도 순위. 밀도가 높은 순서대로 정렬됨. 인덱스 0부터 1위로 시작.",
+        example = "[\"JONGRO\", \"JUNG\", \"YONGSAN\"]")
+    private List<Region> densityRankByRegion;
+
+    public ProjectDensityRankRes(List<Region> densityRankByRegion) {
+        this.densityRankByRegion = densityRankByRegion;
+    }
+}


### PR DESCRIPTION
## 🚀 개발 사항
지역별 프로젝트 밀집도 랭크 조회 기능

### 이슈 번호
- close #40 

## 특이 사항 🫶 
현재 기본 랭킹 limit 는 3.
최소 프로젝트가 1개 이상 있는 지역을 대상으로 랭크를 집계하였고, 
만약 기본 랭킹 limit 보다 돌아온 지역 수가 적다면 (ex. limit 3. 1개이상 프로젝트가 있는 지역이 3개 미만 일때)
기본 지역을 추가로 넣어서 기본 랭킹 limit 을 맞춰 return 한다.
