### PR TITLE
[Bug] 프로젝트, 프로필 카드 랜덤 리스트 조회 API 동작 오류 해결, 불변 리스트 정렬 불가 오류 해결

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationResult.java
+++ b/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationResult.java
@@ -36,6 +36,10 @@ public class CursorPaginationResult<T> {
         this.size = size;
     }
 
+    public void setData(List<T> data) {
+        this.data = data;
+    }
+
     public static <T> CursorPaginationResult<T> fromDataWithExtraItemForNextCheck(
         List<T> data, Integer size
     ) {

--- a/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationResult.java
+++ b/src/main/java/io/oeid/mogakgo/common/base/CursorPaginationResult.java
@@ -37,10 +37,6 @@ public class CursorPaginationResult<T> {
         this.size = size;
     }
 
-    public void setData(List<T> data) {
-        this.data = data;
-    }
-
     public static <T> CursorPaginationResult<T> fromDataWithExtraItemForNextCheck(
         List<T> data, Integer size
     ) {

--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -10,7 +10,9 @@ import io.oeid.mogakgo.domain.profile.infrastructure.ProfileCardJpaRepository;
 import io.oeid.mogakgo.domain.user.application.UserCommonService;
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,12 +31,16 @@ public class ProfileCardService {
         validateToken(userId);
         validateRegionCoverage(region);
 
-        CursorPaginationResult<UserPublicApiResponse> projects = profileCardRepository
+        CursorPaginationResult<UserPublicApiResponse> profiles = profileCardRepository
             .findByConditionWithPagination(
             null, region, pageable
         );
-        Collections.shuffle(projects.getData());
-        return projects;
+
+        List<UserPublicApiResponse> shuffledData = new ArrayList<>(profiles.getData());
+        Collections.shuffle(shuffledData);
+
+        profiles.setData(shuffledData);
+        return profiles;
     }
 
     private User validateToken(Long userId) {

--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -10,9 +10,7 @@ import io.oeid.mogakgo.domain.profile.infrastructure.ProfileCardJpaRepository;
 import io.oeid.mogakgo.domain.user.application.UserCommonService;
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,10 +34,7 @@ public class ProfileCardService {
             null, region, pageable
         );
 
-        List<UserPublicApiResponse> shuffledData = new ArrayList<>(profiles.getData());
-        Collections.shuffle(shuffledData);
-
-        profiles.setData(shuffledData);
+        Collections.shuffle(profiles.getData());
         return profiles;
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/profile/domain/entity/ProfileCard.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/domain/entity/ProfileCard.java
@@ -25,7 +25,7 @@ public class ProfileCard {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "profile_card_id")
+    @Column(name = "id")
     private Long id;
 
     @OneToOne(cascade = CascadeType.ALL)

--- a/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
@@ -1,14 +1,16 @@
 package io.oeid.mogakgo.domain.profile.infrastructure;
 
 import static io.oeid.mogakgo.domain.profile.domain.entity.QProfileCard.profileCard;
-import static io.oeid.mogakgo.domain.project.domain.entity.QProject.project;
+import static io.oeid.mogakgo.domain.user.domain.QUser.user;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
+import io.oeid.mogakgo.domain.profile.domain.entity.ProfileCard;
+import io.oeid.mogakgo.domain.user.domain.UserDevelopLanguageTag;
+import io.oeid.mogakgo.domain.user.domain.UserWantedJobTag;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,21 +26,9 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
     public CursorPaginationResult<UserPublicApiResponse> findByConditionWithPagination(
         Long userId, Region region, CursorPaginationInfoReq pageable
     ) {
-        List<UserPublicApiResponse> result = jpaQueryFactory.select(
-                Projections.constructor(
-                    UserPublicApiResponse.class,
-                    profileCard.user.id,
-                    profileCard.user.username,
-                    profileCard.user.githubId,
-                    profileCard.user.avatarUrl,
-                    profileCard.user.bio,
-                    profileCard.user.jandiRate,
-                    profileCard.user.achievement.title,
-                    profileCard.user.userDevelopLanguageTags,
-                    profileCard.user.userWantedJobTags
-                )
-            )
-            .from(profileCard)
+        List<ProfileCard> entities = jpaQueryFactory.selectFrom(profileCard)
+            .innerJoin(profileCard.user, user)
+            .on(profileCard.user.id.eq(user.id))
             .where(
                 cursorIdCondition(pageable.getCursorId()),
                 userIdEq(userId),
@@ -46,6 +36,23 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
             )
             .limit(pageable.getPageSize() + 1)
             .fetch();
+
+        List<UserPublicApiResponse> result = entities.stream().map(
+            profileCard -> new UserPublicApiResponse(
+                profileCard.getUser().getId(),
+                profileCard.getUser().getUsername(),
+                profileCard.getUser().getGithubId(),
+                profileCard.getUser().getAvatarUrl(),
+                profileCard.getUser().getGithubUrl(),
+                profileCard.getUser().getBio(),
+                profileCard.getUser().getJandiRate(),
+                profileCard.getUser().getAchievement().getTitle(),
+                profileCard.getUser().getUserDevelopLanguageTags().stream().map(
+                    UserDevelopLanguageTag::getDevelopLanguage).map(String::valueOf).toList(),
+                profileCard.getUser().getUserWantedJobTags().stream().map(
+                    UserWantedJobTag::getWantedJob).map(String::valueOf).toList()
+            )
+        ).toList();
 
         return CursorPaginationResult.fromDataWithExtraItemForNextCheck(
             result, pageable.getPageSize()
@@ -61,6 +68,6 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
     }
 
     private BooleanExpression cursorIdCondition(Long cursorId) {
-        return cursorId != null ? project.id.gt(cursorId) : null;
+        return cursorId != null ? profileCard.id.gt(cursorId) : null;
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
@@ -27,7 +27,9 @@ import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.projectJoinR
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.domain.user.exception.UserException;
 import io.oeid.mogakgo.domain.user.infrastructure.UserJpaRepository;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -143,7 +145,10 @@ public class ProjectService {
         );
 
         // 요청할 때마다 랜덤 정렬
-        Collections.shuffle(projects.getData());
+        List<ProjectDetailAPIRes> shuffledData = new ArrayList<>(projects.getData());
+        Collections.shuffle(shuffledData);
+
+        projects.setData(shuffledData);
         return projects;
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
@@ -147,10 +147,7 @@ public class ProjectService {
         );
 
         // 요청할 때마다 랜덤 정렬
-        List<ProjectDetailAPIRes> shuffledData = new ArrayList<>(projects.getData());
-        Collections.shuffle(shuffledData);
-
-        projects.setData(shuffledData);
+        Collections.shuffle(projects.getData());
         return projects;
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -1,17 +1,20 @@
 package io.oeid.mogakgo.domain.project.infrastructure;
 
 import static io.oeid.mogakgo.domain.project.domain.entity.QProject.project;
-import static io.oeid.mogakgo.domain.project.domain.entity.QProjectTag.projectTag;
+import static io.oeid.mogakgo.domain.user.domain.QUser.user;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
+import io.oeid.mogakgo.domain.project.domain.entity.Project;
+import io.oeid.mogakgo.domain.project.domain.entity.ProjectTag;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.MeetingInfoResponse;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
 import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
+import io.oeid.mogakgo.domain.user.domain.UserDevelopLanguageTag;
+import io.oeid.mogakgo.domain.user.domain.UserWantedJobTag;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,32 +30,9 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
     public CursorPaginationResult<ProjectDetailAPIRes> findByConditionWithPagination(
         Long userId, Region region, ProjectStatus projectStatus, CursorPaginationInfoReq pageable
     ) {
-        List<ProjectDetailAPIRes> result = jpaQueryFactory.select(
-                Projections.constructor(
-                    ProjectDetailAPIRes.class,
-                    project.id,
-                    Projections.constructor(
-                        UserPublicApiResponse.class,
-                        project.creator.username,
-                        project.creator.githubId,
-                        project.creator.avatarUrl,
-                        project.creator.githubUrl,
-                        project.creator.bio,
-                        project.creator.jandiRate,
-                        project.creator.userDevelopLanguageTags,
-                        project.creator.userWantedJobTags
-                    ),
-                    projectTag.content,
-                    Projections.constructor(
-                        MeetingInfoResponse.class,
-                        project.meetingInfo.meetStartTime,
-                        project.meetingInfo.meetEndTime,
-                        project.meetingInfo.meetDetail
-                    )
-                )
-            )
-            .from(project)
-            .innerJoin(projectTag).on(project.id.eq(projectTag.project.id))
+        List<Project> entities = jpaQueryFactory.selectFrom(project)
+            .innerJoin(project.creator, user)
+            .on(project.creator.id.eq(user.id))
             .where(
                 cursorIdCondition(pageable.getCursorId()),
                 userIdEq(userId),
@@ -61,6 +41,32 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
             )
             .limit(pageable.getPageSize() + 1)
             .fetch();
+
+        List<ProjectDetailAPIRes> result = entities.stream().map(
+            project -> new ProjectDetailAPIRes(
+                project.getId(),
+                new UserPublicApiResponse(
+                    project.getCreator().getId(),
+                    project.getCreator().getUsername(),
+                    project.getCreator().getGithubId(),
+                    project.getCreator().getAvatarUrl(),
+                    project.getCreator().getGithubUrl(),
+                    project.getCreator().getBio(),
+                    project.getCreator().getJandiRate(),
+                    project.getCreator().getAchievement().getTitle(),
+                    project.getCreator().getUserDevelopLanguageTags().stream().map(
+                        UserDevelopLanguageTag::getDevelopLanguage).map(String::valueOf).toList(),
+                    project.getCreator().getUserWantedJobTags().stream().map(
+                        UserWantedJobTag::getWantedJob).map(String::valueOf).toList()
+                ),
+                project.getProjectTags().stream().map(ProjectTag::getContent).toList(),
+                new MeetingInfoResponse(
+                    project.getMeetingInfo().getMeetStartTime(),
+                    project.getMeetingInfo().getMeetEndTime(),
+                    project.getMeetingInfo().getMeetDetail()
+                )
+            )
+        ).toList();
 
         return CursorPaginationResult.fromDataWithExtraItemForNextCheck(
             result, pageable.getPageSize()

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -33,6 +33,7 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
         List<Project> entities = jpaQueryFactory.selectFrom(project)
             .innerJoin(project.creator, user)
             .on(project.creator.id.eq(user.id))
+            .join(project.projectTags).fetchJoin()
             .where(
                 cursorIdCondition(pageable.getCursorId()),
                 userIdEq(userId),


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 프로젝트, 프로필 카드 리스트 조회 메서드 로직 수정 (파라미터 불일치, 조인 로직 재작성)
- [x] 커서 기반 페이지네이션 `List<T> Data` 불변 리스트 정렬 오류 해결 (setter 추가) 

### 이슈 번호
- close #108 

## 특이 사항 🫶 
- `List<T> Data` 불변 리스트에 대해서 랜덤 정렬 동작 수행 시, 오류가 발생하고, queryDsl에서 랜덤 정렬이 불가능한 점을 고려해보았을 때, 조회한 mutable List로 복제해서 랜덤 정렬을 한 후, setter를 사용하도록 했는데 setter 사용을 지양할 수 있는 다른 방법은 없을지, 더 좋은 해결 방법은 없는지 피드백 부탁드립니다~