### PR TITLE
[BUG] 프로젝트, 프로필 카드 리스트 조회할 때, 업적 조회 시 발생하는 NPE 해결

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
@@ -46,7 +46,7 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
                 profileCard.getUser().getGithubUrl(),
                 profileCard.getUser().getBio(),
                 profileCard.getUser().getJandiRate(),
-                profileCard.getUser().getAchievement().getTitle(),
+                profileCard.getUser().getAchievement() != null ? profileCard.getUser().getAchievement().getTitle() : null,
                 profileCard.getUser().getUserDevelopLanguageTags().stream().map(
                     UserDevelopLanguageTag::getDevelopLanguage).map(String::valueOf).toList(),
                 profileCard.getUser().getUserWantedJobTags().stream().map(

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -54,7 +54,7 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
                     project.getCreator().getGithubUrl(),
                     project.getCreator().getBio(),
                     project.getCreator().getJandiRate(),
-                    project.getCreator().getAchievement().getTitle(),
+                    project.getCreator().getAchievement() != null ? project.getCreator().getAchievement().getTitle() : null,
                     project.getCreator().getUserDevelopLanguageTags().stream().map(
                         UserDevelopLanguageTag::getDevelopLanguage).map(String::valueOf).toList(),
                     project.getCreator().getUserWantedJobTags().stream().map(


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 프로젝트 카드 리스트를 조회하는 과정에서, 빈 업적을 가져올 때 발생하는 NPE 해결

### 이슈 번호
- close #126 

## 특이 사항 🫶 
