### PR TITLE
[FIX] Api 오류들 수정

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectJoinReqSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectJoinReqSwagger.java
@@ -13,6 +13,7 @@ import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinR
 import io.oeid.mogakgo.exception.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -95,8 +96,7 @@ public interface ProjectJoinReqSwagger {
 
     @Operation(summary = "사용자의 프로젝트 요청 리스트 조회", description = "회원이 자신이 보낸 프로젝트 요청 리스트를 조회할 때 사용하는 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "프로젝트 요청 리스트 조회 성공",
-            content = @Content(schema = @Schema(implementation = ProjectJoinRequestDetailAPIRes.class))),
+        @ApiResponse(responseCode = "200", description = "프로젝트 요청 리스트 조회 성공"),
         @ApiResponse(responseCode = "403", description = "본인의 프로젝트 요청만 조회할 수 있음",
             content = @Content(
                 mediaType = "application/json",
@@ -108,6 +108,11 @@ public interface ProjectJoinReqSwagger {
                 mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class),
                 examples = @ExampleObject(name = "E020301", value = SwaggerUserErrorExamples.USER_NOT_FOUND)))
+    })
+    @Parameters({
+        @Parameter(name = "cursorId", description = "기준이 되는 커서 ID", example = "1"),
+        @Parameter(name = "pageSize", description = "요청할 데이터 크기", example = "5", required = true),
+        @Parameter(name = "sortOrder", description = "정렬 방향", example = "ASC"),
     })
     ResponseEntity<CursorPaginationResult<ProjectJoinRequestDetailAPIRes>> getBySenderIdWithPagination(
         @Parameter(hidden = true) Long userId,

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -16,6 +16,7 @@ import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
 import io.oeid.mogakgo.domain.user.domain.UserDevelopLanguageTag;
 import io.oeid.mogakgo.domain.user.domain.UserWantedJobTag;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -30,6 +31,8 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
     public CursorPaginationResult<ProjectDetailAPIRes> findByConditionWithPagination(
         Long userId, Region region, ProjectStatus projectStatus, CursorPaginationInfoReq pageable
     ) {
+        LocalDate today = LocalDate.now();
+
         List<Project> entities = jpaQueryFactory.selectFrom(project)
             .innerJoin(project.creator, user)
             .on(project.creator.id.eq(user.id))
@@ -38,7 +41,8 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
                 cursorIdCondition(pageable.getCursorId()),
                 userIdEq(userId),
                 regionEq(region),
-                projectStatusEq(projectStatus)
+                projectStatusEq(projectStatus),
+                createdAtEq(today)
             )
             .limit(pageable.getPageSize() + 1)
             .fetch();
@@ -99,5 +103,11 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
 
     private BooleanExpression projectStatusEq(ProjectStatus projectStatus) {
         return projectStatus != null ? project.projectStatus.eq(projectStatus) : null;
+    }
+
+    private BooleanExpression createdAtEq(LocalDate today) {
+        return project.createdAt.year().eq(today.getYear())
+            .and(project.createdAt.month().eq(today.getMonthValue()))
+            .and(project.createdAt.dayOfMonth().eq(today.getDayOfMonth()));
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestJpaRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestJpaRepository.java
@@ -20,7 +20,7 @@ public interface ProjectJoinRequestJpaRepository extends JpaRepository<ProjectJo
     @Query("select pjr from ProjectJoinRequest pjr where pjr.sender.id = :userId and pjr.project.id = :projectId")
     Optional<ProjectJoinRequest> findAlreadyExists(Long userId, Long projectId);
 
-    @Query("select pjr from ProjectJoinRequest pjr where pjr.sender.id = :userId")
+    @Query("select pjr from ProjectJoinRequest pjr where pjr.sender.id = :userId and pjr.requestStatus = 'PENDING'")
     Optional<ProjectJoinRequest> findAlreadyExistsAnotherJoinReq(Long userId);
 
     @Modifying

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
@@ -1,5 +1,6 @@
 package io.oeid.mogakgo.domain.project_join_req.presentation.dto.res;
 
+import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.MeetingInfoResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -13,24 +14,29 @@ public class ProjectJoinRequestDetailAPIRes {
     @NotNull
     private final Long projectId;
 
+    @Schema(description = "프로젝트 상태", example = "PENDING", implementation = ProjectStatus.class)
+    @NotNull
+    private final ProjectStatus projectStatus;
+
     @Schema(description = "프로젝트 생성자 아바타 URL", example = "https://avatars.githubusercontent.com/u/85854384?v=4")
     private final String creatorAvatorUrl;
 
     @Schema(description = "프로젝트 만남 장ㅔ")
     private final MeetingInfoResponse meetingInfo;
 
-    public ProjectJoinRequestDetailAPIRes(
-        Long projectId, String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    public ProjectJoinRequestDetailAPIRes(Long projectId, ProjectStatus projectStatus,
+        String creatorAvatorUrl, MeetingInfoResponse meetingInfo
     ) {
         this.projectId = projectId;
+        this.projectStatus = projectStatus;
         this.creatorAvatorUrl = creatorAvatorUrl;
         this.meetingInfo = meetingInfo;
     }
 
-    public static ProjectJoinRequestDetailAPIRes from(
-        Long projectId, String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    public static ProjectJoinRequestDetailAPIRes from(Long projectId, ProjectStatus projectStatus,
+        String creatorAvatorUrl, MeetingInfoResponse meetingInfo
     ) {
-        return new ProjectJoinRequestDetailAPIRes(projectId, creatorAvatorUrl, meetingInfo);
+        return new ProjectJoinRequestDetailAPIRes(projectId, projectStatus, creatorAvatorUrl, meetingInfo);
     }
 
 }


### PR DESCRIPTION
## 🚀 개발 사항

스웨거 문서 페이지네이션 정보 누락 오류 수정

- 페이지네이션 정보가 누락 되었습니다. 쿼리 파라미터로 받는 정보들은 메서드 위에  @Parameters 로 선언 해줘야만 스웨거 문서 상에서 볼 수 있습니다.
- 제네릭을 사용해서 return value 를 명시하는 컨트롤러는 content 를 따로 지정하지 않아야 제대로 return 값이 나타납니다. 현재 경우도 동일한 경우로 content 지정한 부분을 제거하였습니다.

프로젝트 요청 보내기 유효성 검사 쿼리 오류 수정

- 본인이 보낸 대기상태의 요청이 있는 경우 다른 프로젝트에 요청을 보낼 수 없습니다. 해당 유효성 검사에서 'PENDING' 상태의 요청 존재 여부만 체크해야 하는데 모든 상태의 요청 존재 여부를 체크해 오류가 발생 하였습니다. 따라서 쿼리에 'PENDING' 상태의 요청만 가져오게 수정 하였습니다.

### 이슈 번호
- close

## 특이 사항 🫶 
