### PR TITLE
[REFACT] 프로젝트 생성일 유효성 검사, 프로젝트 상태 유효성 검사, 프로젝트 상태 필드 추가

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -16,6 +16,7 @@ import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
 import io.oeid.mogakgo.domain.user.domain.UserDevelopLanguageTag;
 import io.oeid.mogakgo.domain.user.domain.UserWantedJobTag;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -30,6 +31,8 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
     public CursorPaginationResult<ProjectDetailAPIRes> findByConditionWithPagination(
         Long userId, Region region, ProjectStatus projectStatus, CursorPaginationInfoReq pageable
     ) {
+        LocalDate today = LocalDate.now();
+
         List<Project> entities = jpaQueryFactory.selectFrom(project)
             .innerJoin(project.creator, user)
             .on(project.creator.id.eq(user.id))
@@ -38,7 +41,8 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
                 cursorIdCondition(pageable.getCursorId()),
                 userIdEq(userId),
                 regionEq(region),
-                projectStatusEq(projectStatus)
+                projectStatusEq(projectStatus),
+                createdAtEq(today)
             )
             .limit(pageable.getPageSize() + 1)
             .fetch();
@@ -99,5 +103,11 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
 
     private BooleanExpression projectStatusEq(ProjectStatus projectStatus) {
         return projectStatus != null ? project.projectStatus.eq(projectStatus) : null;
+    }
+
+    private BooleanExpression createdAtEq(LocalDate today) {
+        return project.createdAt.year().eq(today.getYear())
+            .and(project.createdAt.month().eq(today.getMonthValue()))
+            .and(project.createdAt.dayOfMonth().eq(today.getDayOfMonth()));
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/application/ProjectJoinRequestService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/application/ProjectJoinRequestService.java
@@ -51,7 +51,7 @@ public class ProjectJoinRequestService {
         User tokenUser = validateToken(userId);
         validateSender(tokenUser, request.getSenderId());
         Project project = validateProjectExist(request.getProjectId());
-        validateProjectStatus(project.getProjectStatus());
+        validateProjectStatus(project.getProjectStatus()); // 요청을 보내려는 프로젝트가 대기중이 맞는지 검사
         validateProjectCreator(project, userId);
         validateUserCertRegion(project, tokenUser);
         validateAlreadyExistRequest(userId, project.getId());

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/application/ProjectJoinRequestService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/application/ProjectJoinRequestService.java
@@ -16,6 +16,7 @@ import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.matching.application.MatchingService;
 import io.oeid.mogakgo.domain.matching.application.UserMatchingService;
 import io.oeid.mogakgo.domain.project.domain.entity.Project;
+import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.project.exception.ProjectException;
 import io.oeid.mogakgo.domain.project.infrastructure.ProjectJpaRepository;
 import io.oeid.mogakgo.domain.project_join_req.application.dto.req.ProjectJoinCreateReq;
@@ -27,6 +28,7 @@ import io.oeid.mogakgo.domain.user.application.UserCommonService;
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.domain.user.exception.UserException;
 import io.oeid.mogakgo.domain.user.infrastructure.UserJpaRepository;
+import io.oeid.mogakgo.exception.code.ErrorCode400;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +51,7 @@ public class ProjectJoinRequestService {
         User tokenUser = validateToken(userId);
         validateSender(tokenUser, request.getSenderId());
         Project project = validateProjectExist(request.getProjectId());
+        validateProjectStatus(project.getProjectStatus());
         validateProjectCreator(project, userId);
         validateUserCertRegion(project, tokenUser);
         validateAlreadyExistRequest(userId, project.getId());
@@ -139,6 +142,12 @@ public class ProjectJoinRequestService {
     private Project validateProjectExist(Long projectId) {
         return projectRepository.findById(projectId)
             .orElseThrow(() -> new ProjectException(PROJECT_NOT_FOUND));
+    }
+
+    private void validateProjectStatus(ProjectStatus projectStatus) {
+        if (!projectStatus.equals(ProjectStatus.PENDING)) {
+            throw new ProjectJoinRequestException(ErrorCode400.INVALID_PROJECT_STATUS_TO_ACCEPT);
+        }
     }
 
     private void validateProjectCreator(Project project, Long userId) {

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
@@ -1,5 +1,6 @@
 package io.oeid.mogakgo.domain.project_join_req.presentation.dto.res;
 
+import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.MeetingInfoResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -13,24 +14,29 @@ public class ProjectJoinRequestDetailAPIRes {
     @NotNull
     private final Long projectId;
 
+    @Schema(description = "프로젝트 상태", example = "PENDING", implementation = ProjectStatus.class)
+    @NotNull
+    private final ProjectStatus projectStatus;
+
     @Schema(description = "프로젝트 생성자 아바타 URL", example = "https://avatars.githubusercontent.com/u/85854384?v=4")
     private final String creatorAvatorUrl;
 
     @Schema(description = "프로젝트 만남 장ㅔ")
     private final MeetingInfoResponse meetingInfo;
 
-    public ProjectJoinRequestDetailAPIRes(
-        Long projectId, String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    public ProjectJoinRequestDetailAPIRes(Long projectId, ProjectStatus projectStatus,
+        String creatorAvatorUrl, MeetingInfoResponse meetingInfo
     ) {
         this.projectId = projectId;
+        this.projectStatus = projectStatus;
         this.creatorAvatorUrl = creatorAvatorUrl;
         this.meetingInfo = meetingInfo;
     }
 
-    public static ProjectJoinRequestDetailAPIRes from(
-        Long projectId, String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    public static ProjectJoinRequestDetailAPIRes from(Long projectId, ProjectStatus projectStatus,
+        String creatorAvatorUrl, MeetingInfoResponse meetingInfo
     ) {
-        return new ProjectJoinRequestDetailAPIRes(projectId, creatorAvatorUrl, meetingInfo);
+        return new ProjectJoinRequestDetailAPIRes(projectId, projectStatus, creatorAvatorUrl, meetingInfo);
     }
 
 }


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 프로젝트 카드 랜덤 리스트 조회 시, 당일에 생성된 프로젝트 리스트만 조회하도록 유효성 검사 추가
- [x] 프로젝트 카드에 매칭 요청 생성 시, 해당 프로젝트가 'PENDING' 상태가 맞는지 유효성 검사 추가
- [x] 프로젝트 요청 리스트 조회 시, 프로젝트의 상태 필드를 추가  

### 이슈 번호
- close #130 

## 특이 사항 🫶 
