### PR TITLE
Feat/#145, 146 websocket chat

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ChatSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ChatSwagger.java
@@ -1,0 +1,55 @@
+package io.oeid.mogakgo.common.swagger.template;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import io.oeid.mogakgo.core.properties.swagger.error.SwaggerChatErrorExamples;
+import io.oeid.mogakgo.core.properties.swagger.error.SwaggerProjectErrorExamples;
+import io.oeid.mogakgo.core.properties.swagger.error.SwaggerUserErrorExamples;
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomDataRes;
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomPublicRes;
+import io.oeid.mogakgo.exception.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Chat", description = "채팅 관련 API")
+@SuppressWarnings("unused")
+public interface ChatSwagger {
+
+    @Operation(summary = "채팅방 목록 조회", description = "사용자의 채팅방 목록을 조회하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "채팅방 목록 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "요청한 유저가 존재하지 않음",
+        content = @Content(
+            mediaType = APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ErrorResponse.class),
+            examples = @ExampleObject(name = "E020301", value =  SwaggerUserErrorExamples.USER_NOT_FOUND)
+        ))
+    })
+    ResponseEntity<List<ChatRoomPublicRes>> getChatRoomList(@Parameter(hidden = true) Long userId);
+
+    @Operation(summary = "채팅방 상세 조회", description = "채팅방의 상세 정보를 조회하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "채팅방 상세 조회 성공"),
+        @ApiResponse(responseCode = "404", description = "요청한 데이터가 유효하지 않음",
+        content = @Content(
+            mediaType = APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ErrorResponse.class),
+            examples = {
+                @ExampleObject(name = "E020301", value = SwaggerUserErrorExamples.USER_NOT_FOUND),
+                @ExampleObject(name = "E030301", value = SwaggerProjectErrorExamples.PROJECT_NOT_FOUND),
+                @ExampleObject(name = "E110301", value = SwaggerChatErrorExamples.CHAT_ROOM_NOT_FOUND)
+            }
+        ))
+    })
+    ResponseEntity<ChatRoomDataRes> getChatRoomDetailData(@Parameter(hidden = true) Long userId,
+        @Parameter(in = ParameterIn.PATH) String chatRoomId);
+}

--- a/src/main/java/io/oeid/mogakgo/core/configuration/WebSocketConfig.java
+++ b/src/main/java/io/oeid/mogakgo/core/configuration/WebSocketConfig.java
@@ -1,0 +1,21 @@
+package io.oeid.mogakgo.core.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final WebSocketHandler webSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/ws/chat").setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerChatErrorExamples.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerChatErrorExamples.java
@@ -1,0 +1,9 @@
+package io.oeid.mogakgo.core.properties.swagger.error;
+
+public class SwaggerChatErrorExamples {
+
+    public static final String CHAT_ROOM_NOT_FOUND = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":404,\"code\":\"E110301\",\"message\":\"해당 채팅방이 존재하지 않습니다.\"}";
+
+    private SwaggerChatErrorExamples() {
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
@@ -1,7 +1,9 @@
 package io.oeid.mogakgo.domain.chat.application;
 
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomCreateRes;
 import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
-import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomRepository;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRepository;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomJpaRepository;
 import io.oeid.mogakgo.domain.user.application.UserCommonService;
 import io.oeid.mogakgo.domain.user.domain.User;
 import java.util.List;
@@ -17,22 +19,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatService {
 
     private final UserCommonService userCommonService;
-    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomJpaRepository chatRoomJpaRepository;
+    private final ChatRepository chatRepository;
 
     public List<ChatRoom> findAllChatRoomByUserId(Long userId) {
         User user = userCommonService.getUserById(userId);
-        return chatRoomRepository.findAllByUserId(user.getId());
+        return chatRoomJpaRepository.findAllByUserId(user.getId());
     }
 
     @Transactional
-    public ChatRoom createChatRoom(Long creatorId, Long senderId, String name) {
+    public ChatRoomCreateRes createChatRoom(Long creatorId, Long senderId, String name) {
         User creator = userCommonService.getUserById(creatorId);
         User sender = userCommonService.getUserById(senderId);
-        ChatRoom chatRoom = ChatRoom.builder()
-            .creator(creator)
-            .sender(sender)
-            .name(name)
-            .build();
-        return chatRoomRepository.save(chatRoom);
+        ChatRoom chatRoom = chatRoomJpaRepository.save(
+            ChatRoom.builder().creator(creator).sender(sender).name(name).build());
+        chatRepository.createCollection(chatRoom.getId());
+        return ChatRoomCreateRes.from(chatRoom);
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
@@ -1,0 +1,38 @@
+package io.oeid.mogakgo.domain.chat.application;
+
+import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomRepository;
+import io.oeid.mogakgo.domain.user.application.UserCommonService;
+import io.oeid.mogakgo.domain.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final UserCommonService userCommonService;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public List<ChatRoom> findAllChatRoomByUserId(Long userId) {
+        User user = userCommonService.getUserById(userId);
+        return chatRoomRepository.findAllByUserId(user.getId());
+    }
+
+    @Transactional
+    public ChatRoom createChatRoom(Long creatorId, Long senderId, String name) {
+        User creator = userCommonService.getUserById(creatorId);
+        User sender = userCommonService.getUserById(senderId);
+        ChatRoom chatRoom = ChatRoom.builder()
+            .creator(creator)
+            .sender(sender)
+            .name(name)
+            .build();
+        return chatRoomRepository.save(chatRoom);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
@@ -34,6 +34,7 @@ public class ChatService {
     // 채팅방 리스트 조회
     // TODO 마지막 채팅 기록 가져오기 구현
     public List<ChatRoomPublicRes> findAllChatRoomByUserId(Long userId) {
+        userCommonService.getUserById(userId);
         return chatRoomRepository.findAllChatRoomByUserId(userId);
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
@@ -6,7 +6,7 @@ import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomDataRes;
 import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomPublicRes;
 import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRepository;
-import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomJpaRepository;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomRoomJpaRepository;
 import io.oeid.mogakgo.domain.matching.exception.MatchingException;
 import io.oeid.mogakgo.domain.project.domain.entity.Project;
 import io.oeid.mogakgo.domain.project.exception.ProjectException;
@@ -27,16 +27,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatService {
 
     private final UserCommonService userCommonService;
-    private final ChatRoomJpaRepository chatRoomRepository;
+    private final ChatRoomRoomJpaRepository chatRoomRepository;
     private final ChatRepository chatRepository;
     private final ProjectJpaRepository projectRepository;
 
     // 채팅방 리스트 조회
     // TODO 마지막 채팅 기록 가져오기 구현
     public List<ChatRoomPublicRes> findAllChatRoomByUserId(Long userId) {
-        User user = userCommonService.getUserById(userId);
-        return null;
-        //return chatRoomRepository.findAllByUserId(user.getId());
+        return chatRoomRepository.findAllChatRoomByUserId(userId);
     }
 
     // 채팅방 생성

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatService.java
@@ -1,11 +1,19 @@
 package io.oeid.mogakgo.domain.chat.application;
 
+import io.oeid.mogakgo.domain.chat.application.dto.req.ChatRoomCreateReq;
 import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomCreateRes;
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomDataRes;
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomPublicRes;
 import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRepository;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomJpaRepository;
+import io.oeid.mogakgo.domain.matching.exception.MatchingException;
+import io.oeid.mogakgo.domain.project.domain.entity.Project;
+import io.oeid.mogakgo.domain.project.exception.ProjectException;
+import io.oeid.mogakgo.domain.project.infrastructure.ProjectJpaRepository;
 import io.oeid.mogakgo.domain.user.application.UserCommonService;
 import io.oeid.mogakgo.domain.user.domain.User;
+import io.oeid.mogakgo.exception.code.ErrorCode404;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,21 +27,40 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatService {
 
     private final UserCommonService userCommonService;
-    private final ChatRoomJpaRepository chatRoomJpaRepository;
+    private final ChatRoomJpaRepository chatRoomRepository;
     private final ChatRepository chatRepository;
+    private final ProjectJpaRepository projectRepository;
 
-    public List<ChatRoom> findAllChatRoomByUserId(Long userId) {
+    // 채팅방 리스트 조회
+    // TODO 마지막 채팅 기록 가져오기 구현
+    public List<ChatRoomPublicRes> findAllChatRoomByUserId(Long userId) {
         User user = userCommonService.getUserById(userId);
-        return chatRoomJpaRepository.findAllByUserId(user.getId());
+        return null;
+        //return chatRoomRepository.findAllByUserId(user.getId());
     }
 
+    // 채팅방 생성
     @Transactional
-    public ChatRoomCreateRes createChatRoom(Long creatorId, Long senderId, String name) {
+    public ChatRoomCreateRes createChatRoom(Long creatorId, ChatRoomCreateReq request) {
+        Project project = projectRepository.findById(request.getProjectId())
+            .orElseThrow(() -> new MatchingException(ErrorCode404.PROJECT_NOT_FOUND));
         User creator = userCommonService.getUserById(creatorId);
-        User sender = userCommonService.getUserById(senderId);
-        ChatRoom chatRoom = chatRoomJpaRepository.save(
-            ChatRoom.builder().creator(creator).sender(sender).name(name).build());
+        User sender = userCommonService.getUserById(request.getSenderId());
+        ChatRoom chatRoom = chatRoomRepository.save(
+            ChatRoom.builder().project(project).creator(creator).sender(sender).build());
         chatRepository.createCollection(chatRoom.getId());
         return ChatRoomCreateRes.from(chatRoom);
+    }
+
+    // 채팅방 조회
+    public ChatRoomDataRes findAllChatInChatRoom(Long userId, String chatRoomId) {
+        var user = userCommonService.getUserById(userId);
+        var chatRoom = chatRoomRepository.findById(chatRoomId)
+            .orElseThrow(() -> new MatchingException(ErrorCode404.CHAT_ROOM_NOT_FOUND));
+        chatRoom.validateContainsUser(user);
+        var project = projectRepository.findById(chatRoom.getProject().getId())
+            .orElseThrow(() -> new ProjectException(ErrorCode404.PROJECT_NOT_FOUND));
+        var chatList = chatRepository.findAllByCollection(chatRoomId);
+        return ChatRoomDataRes.of(project.getMeetingInfo(), chatList);
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
@@ -1,43 +1,68 @@
 package io.oeid.mogakgo.domain.chat.application;
 
 
+import static io.oeid.mogakgo.exception.code.ErrorCode500.CHAT_WEB_SOCKET_ERROR;
+
 import io.oeid.mogakgo.domain.chat.entity.document.ChatMessage;
 import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
 import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
 import io.oeid.mogakgo.domain.chat.exception.ChatException;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRepository;
-import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomRepository;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomJpaRepository;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomSessionRepository;
 import io.oeid.mogakgo.exception.code.ErrorCode400;
 import io.oeid.mogakgo.exception.code.ErrorCode404;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class ChatWebSocketService {
 
-    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomJpaRepository chatRoomJpaRepository;
     private final ChatRepository chatRepository;
+    private final ChatRoomSessionRepository chatRoomSessionRepository;
 
     @Transactional(readOnly = true)
     public ChatRoom findChatRoomById(String roomId) {
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new ChatException(ErrorCode404.CHAT_ROOM_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomJpaRepository.findById(roomId).orElseThrow(() -> new ChatException(ErrorCode404.CHAT_ROOM_NOT_FOUND));
         if(chatRoom.getStatus().equals(ChatStatus.CLOSED)){
             throw new ChatException(ErrorCode400.CHAT_ROOM_CLOSED);
         }
         return chatRoom;
     }
 
-    public void manageChatCollections(String roomId) {
-        chatRepository.createCollection(roomId);
-    }
-
     public void saveChatMessage(ChatMessage chatMessage, String roomId) {
         chatRepository.save(chatMessage, roomId);
     }
 
+    public void closeChatRoom(String roomId) {
+        ChatRoom chatRoom = chatRoomJpaRepository.findById(roomId).orElseThrow(() -> new ChatException(ErrorCode404.CHAT_ROOM_NOT_FOUND));
+        chatRoomSessionRepository.removeRoom(chatRoom.getId());
+        chatRoom.closeChat();
+    }
 
+    public void addSessionToRoom(String roomId, WebSocketSession session) {
+        chatRoomSessionRepository.addSession(roomId, session);
+    }
+
+    public void removeSessionFromRoom(String roomId, WebSocketSession session) {
+        chatRoomSessionRepository.removeSession(roomId, session);
+    }
+
+    public void sendMessageToEachSocket(String roomId, TextMessage textMessage){
+        chatRoomSessionRepository.getSession(roomId).forEach(session -> {
+            try {
+                session.sendMessage(textMessage);
+            } catch (Exception e) {
+                log.error("sendMessageToEachSocket: {}", e.getMessage());
+                throw new ChatException(CHAT_WEB_SOCKET_ERROR);
+            }
+        });
+    }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
@@ -8,7 +8,7 @@ import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
 import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
 import io.oeid.mogakgo.domain.chat.exception.ChatException;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRepository;
-import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomJpaRepository;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomRoomJpaRepository;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomSessionRepository;
 import io.oeid.mogakgo.exception.code.ErrorCode400;
 import io.oeid.mogakgo.exception.code.ErrorCode404;
@@ -24,7 +24,7 @@ import org.springframework.web.socket.WebSocketSession;
 @Service
 public class ChatWebSocketService {
 
-    private final ChatRoomJpaRepository chatRoomJpaRepository;
+    private final ChatRoomRoomJpaRepository chatRoomJpaRepository;
     private final ChatRepository chatRepository;
     private final ChatRoomSessionRepository chatRoomSessionRepository;
 

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
@@ -3,9 +3,11 @@ package io.oeid.mogakgo.domain.chat.application;
 
 import io.oeid.mogakgo.domain.chat.entity.document.ChatMessage;
 import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
+import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
 import io.oeid.mogakgo.domain.chat.exception.ChatException;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRepository;
 import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomRepository;
+import io.oeid.mogakgo.exception.code.ErrorCode400;
 import io.oeid.mogakgo.exception.code.ErrorCode404;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +24,11 @@ public class ChatWebSocketService {
 
     @Transactional(readOnly = true)
     public ChatRoom findChatRoomById(String roomId) {
-        return chatRoomRepository.findById(roomId).orElseThrow(() -> new ChatException(ErrorCode404.CHAT_ROOM_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(() -> new ChatException(ErrorCode404.CHAT_ROOM_NOT_FOUND));
+        if(chatRoom.getStatus().equals(ChatStatus.CLOSED)){
+            throw new ChatException(ErrorCode400.CHAT_ROOM_CLOSED);
+        }
+        return chatRoom;
     }
 
     public void manageChatCollections(String roomId) {

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/ChatWebSocketService.java
@@ -1,0 +1,37 @@
+package io.oeid.mogakgo.domain.chat.application;
+
+
+import io.oeid.mogakgo.domain.chat.entity.document.ChatMessage;
+import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
+import io.oeid.mogakgo.domain.chat.exception.ChatException;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRepository;
+import io.oeid.mogakgo.domain.chat.infrastructure.ChatRoomRepository;
+import io.oeid.mogakgo.exception.code.ErrorCode404;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatWebSocketService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRepository chatRepository;
+
+    @Transactional(readOnly = true)
+    public ChatRoom findChatRoomById(String roomId) {
+        return chatRoomRepository.findById(roomId).orElseThrow(() -> new ChatException(ErrorCode404.CHAT_ROOM_NOT_FOUND));
+    }
+
+    public void manageChatCollections(String roomId) {
+        chatRepository.createCollection(roomId);
+    }
+
+    public void saveChatMessage(ChatMessage chatMessage, String roomId) {
+        chatRepository.save(chatMessage, roomId);
+    }
+
+
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/req/ChatRoomCreateReq.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/req/ChatRoomCreateReq.java
@@ -1,0 +1,11 @@
+package io.oeid.mogakgo.domain.chat.application.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomCreateReq {
+    private Long projectId;
+    private Long senderId;
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomCreateRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomCreateRes.java
@@ -8,22 +8,22 @@ import lombok.Getter;
 public class ChatRoomCreateRes {
 
     private String roomId;
-    private String name;
+    private Long projectId;
     private Long creatorId;
     private Long senderId;
     private ChatStatus chatStatus;
 
-    private ChatRoomCreateRes(String roomId, String name, Long creatorId, Long senderId,
+    private ChatRoomCreateRes(String roomId, Long projectId, Long creatorId, Long senderId,
         ChatStatus chatStatus) {
         this.roomId = roomId;
-        this.name = name;
+        this.projectId = projectId;
         this.creatorId = creatorId;
         this.senderId = senderId;
         this.chatStatus = chatStatus;
     }
 
     public static ChatRoomCreateRes from(ChatRoom chatRoom) {
-        return new ChatRoomCreateRes(chatRoom.getId(), chatRoom.getName(),
+        return new ChatRoomCreateRes(chatRoom.getId(), chatRoom.getProject().getId(),
             chatRoom.getCreator().getId(), chatRoom.getSender().getId(), chatRoom.getStatus());
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomCreateRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomCreateRes.java
@@ -1,0 +1,30 @@
+package io.oeid.mogakgo.domain.chat.application.dto.res;
+
+import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
+import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomCreateRes {
+
+    private String roomId;
+    private String name;
+    private Long creatorId;
+    private Long senderId;
+    private ChatStatus chatStatus;
+
+    private ChatRoomCreateRes(String roomId, String name, Long creatorId, Long senderId,
+        ChatStatus chatStatus) {
+        this.roomId = roomId;
+        this.name = name;
+        this.creatorId = creatorId;
+        this.senderId = senderId;
+        this.chatStatus = chatStatus;
+    }
+
+    public static ChatRoomCreateRes from(ChatRoom chatRoom) {
+        return new ChatRoomCreateRes(chatRoom.getId(), chatRoom.getName(),
+            chatRoom.getCreator().getId(), chatRoom.getSender().getId(), chatRoom.getStatus());
+    }
+
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomDataRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomDataRes.java
@@ -1,0 +1,28 @@
+package io.oeid.mogakgo.domain.chat.application.dto.res;
+
+import io.oeid.mogakgo.domain.chat.application.vo.ChatData;
+import io.oeid.mogakgo.domain.chat.application.vo.ChatRoomProjectInfo;
+import io.oeid.mogakgo.domain.chat.entity.document.ChatMessage;
+import io.oeid.mogakgo.domain.project.domain.entity.vo.MeetingInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "채팅방 데이터 조회 응답")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class ChatRoomDataRes {
+
+    private ChatRoomProjectInfo project;
+    private List<ChatData> data;
+
+    public static ChatRoomDataRes of(MeetingInfo meetingInfo, List<ChatMessage> data) {
+        ChatRoomProjectInfo project = new ChatRoomProjectInfo(meetingInfo.getMeetDetail(),
+            meetingInfo.getMeetStartTime(), meetingInfo.getMeetEndTime());
+        return new ChatRoomDataRes(project, data.stream().map(ChatData::from).toList());
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomPublicRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomPublicRes.java
@@ -1,0 +1,5 @@
+package io.oeid.mogakgo.domain.chat.application.dto.res;
+
+public class ChatRoomPublicRes {
+
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomPublicRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/dto/res/ChatRoomPublicRes.java
@@ -1,5 +1,27 @@
 package io.oeid.mogakgo.domain.chat.application.dto.res;
 
-public class ChatRoomPublicRes {
+import io.oeid.mogakgo.domain.chat.application.vo.ChatUserInfo;
+import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Schema(description = "채팅방 리스트 조회 응답")
+@Getter
+@AllArgsConstructor
+public class ChatRoomPublicRes {
+    @Schema(description = "프로젝트 ID")
+    private Long projectId;
+    @Schema(description = "채팅방 ID")
+    private String chatRoomId;
+    @Schema(description = "마지막 메시지")
+    private String lastMessage;
+    @Schema(description = "마지막 메시지 생성 시간")
+    private LocalDateTime lastMessageCreatedAt;
+    @Schema(description = "채팅방 상태")
+    private ChatStatus status;
+
+    private List<ChatUserInfo> profiles;
 }

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/vo/ChatData.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/vo/ChatData.java
@@ -1,0 +1,29 @@
+package io.oeid.mogakgo.domain.chat.application.vo;
+
+import io.oeid.mogakgo.domain.chat.entity.document.ChatMessage;
+import io.oeid.mogakgo.domain.chat.entity.enums.ChatMessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "채팅 데이터")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatData {
+
+    @Schema(description = "메시지 타입")
+    private ChatMessageType messageType;
+    @Schema(description = "보낸 사람 ID")
+    private Long senderId;
+    @Schema(description = "메시지")
+    private String message;
+    @Schema(description = "생성 시간")
+    private LocalDateTime createdAt;
+
+    public static ChatData from(ChatMessage chatMessage) {
+        return new ChatData(chatMessage.getMessageType(), chatMessage.getSenderId(),
+            chatMessage.getMessage(), chatMessage.getCreatedAt());
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/vo/ChatRoomProjectInfo.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/vo/ChatRoomProjectInfo.java
@@ -1,0 +1,19 @@
+package io.oeid.mogakgo.domain.chat.application.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "채팅방 프로젝트 정보")
+@Getter
+@AllArgsConstructor
+public class ChatRoomProjectInfo {
+
+    @Schema(description = "프로젝트 설명")
+    private String meetDetail;
+    @Schema(description = "프로젝트 시작 시간")
+    private LocalDateTime meetStartTime;
+    @Schema(description = "프로젝트 종료 시간")
+    private LocalDateTime meetEndTime;
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/application/vo/ChatUserInfo.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/application/vo/ChatUserInfo.java
@@ -1,0 +1,17 @@
+package io.oeid.mogakgo.domain.chat.application.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "채팅방 유저 정보")
+@Getter
+@AllArgsConstructor
+public class ChatUserInfo {
+    @Schema(description = "유저 ID")
+    private Long userId;
+    @Schema(description = "유저 이름")
+    private String username;
+    @Schema(description = "유저 프로필 이미지 URL")
+    private String avatarUrl;
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatMessage.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatMessage.java
@@ -8,14 +8,14 @@ import lombok.Getter;
 public class ChatMessage {
 
     private ChatMessageType messageType;
-    private String roomId;
-    private String senderId;
+    private String chatRoomId;
+    private Long senderId;
     private String message;
     private LocalDateTime createdAt;
 
-    public ChatMessage(ChatMessageType messageType, String roomId, String senderId, String message) {
+    public ChatMessage(ChatMessageType messageType, String chatRoomId, Long senderId, String message) {
         this.messageType = messageType;
-        this.roomId = roomId;
+        this.chatRoomId = chatRoomId;
         this.senderId = senderId;
         this.message = message;
         this.createdAt = LocalDateTime.now();

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatMessage.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatMessage.java
@@ -1,17 +1,20 @@
 package io.oeid.mogakgo.domain.chat.entity.document;
 
+import io.oeid.mogakgo.domain.chat.entity.enums.ChatMessageType;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
 public class ChatMessage {
 
+    private ChatMessageType messageType;
     private String roomId;
     private String senderId;
     private String message;
     private LocalDateTime createdAt;
 
-    public ChatMessage(String roomId, String senderId, String message) {
+    public ChatMessage(ChatMessageType messageType, String roomId, String senderId, String message) {
+        this.messageType = messageType;
         this.roomId = roomId;
         this.senderId = senderId;
         this.message = message;

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatMessage.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatMessage.java
@@ -1,0 +1,20 @@
+package io.oeid.mogakgo.domain.chat.entity.document;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ChatMessage {
+
+    private String roomId;
+    private String senderId;
+    private String message;
+    private LocalDateTime createdAt;
+
+    public ChatMessage(String roomId, String senderId, String message) {
+        this.roomId = roomId;
+        this.senderId = senderId;
+        this.message = message;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatRoom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatRoom.java
@@ -2,6 +2,7 @@ package io.oeid.mogakgo.domain.chat.entity.document;
 
 import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
 import io.oeid.mogakgo.domain.chat.exception.ChatException;
+import io.oeid.mogakgo.domain.project.domain.entity.Project;
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.exception.code.ErrorCode400;
 import jakarta.persistence.Column;
@@ -31,8 +32,9 @@ public class ChatRoom {
     @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
-    @Column(name = "name")
-    private String name;
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
 
     @ManyToOne
     @JoinColumn(name = "creator_id")
@@ -46,10 +48,11 @@ public class ChatRoom {
     @Column(name = "status")
     private ChatStatus status;
 
+
     @Builder
-    private ChatRoom(String name, User creator, User sender) {
-        this.name = name;
+    private ChatRoom(Project project, User creator, User sender) {
         validateUsers(creator, sender);
+        this.project = project;
         this.creator = creator;
         this.sender = sender;
         this.status = ChatStatus.OPEN;
@@ -62,6 +65,12 @@ public class ChatRoom {
     private void validateUsers(User creator, User sender) {
         if (creator.equals(sender)) {
             throw new ChatException(ErrorCode400.CHAT_ROOM_USER_CANNOT_DUPLICATE);
+        }
+    }
+
+    public void validateContainsUser(User user) {
+        if (!creator.equals(user) && !sender.equals(user)) {
+            throw new ChatException(ErrorCode400.CHAT_ROOM_USER_NOT_CONTAINS);
         }
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatRoom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatRoom.java
@@ -1,0 +1,65 @@
+package io.oeid.mogakgo.domain.chat.entity.document;
+
+import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
+import io.oeid.mogakgo.domain.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.socket.WebSocketSession;
+
+
+@Entity
+@Getter
+@Table(name = "chat_room_tb")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @Column(name = "name")
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "creator_id")
+    private User creator;
+
+    @ManyToOne
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private ChatStatus status;
+
+    @Transient
+    private final Set<WebSocketSession> sessions = new HashSet<>();
+
+    @Builder
+    private ChatRoom(String name, User creator, User sender) {
+        this.name = name;
+        this.creator = creator;
+        this.sender = sender;
+        this.status = ChatStatus.OPEN;
+    }
+
+    public void closeChat() {
+        this.status = ChatStatus.CLOSED;
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatRoom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/document/ChatRoom.java
@@ -1,7 +1,9 @@
 package io.oeid.mogakgo.domain.chat.entity.document;
 
 import io.oeid.mogakgo.domain.chat.entity.enums.ChatStatus;
+import io.oeid.mogakgo.domain.chat.exception.ChatException;
 import io.oeid.mogakgo.domain.user.domain.User;
+import io.oeid.mogakgo.exception.code.ErrorCode400;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,14 +14,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.socket.WebSocketSession;
 
 
 @Entity
@@ -48,12 +46,10 @@ public class ChatRoom {
     @Column(name = "status")
     private ChatStatus status;
 
-    @Transient
-    private final Set<WebSocketSession> sessions = new HashSet<>();
-
     @Builder
     private ChatRoom(String name, User creator, User sender) {
         this.name = name;
+        validateUsers(creator, sender);
         this.creator = creator;
         this.sender = sender;
         this.status = ChatStatus.OPEN;
@@ -62,4 +58,11 @@ public class ChatRoom {
     public void closeChat() {
         this.status = ChatStatus.CLOSED;
     }
+
+    private void validateUsers(User creator, User sender) {
+        if (creator.equals(sender)) {
+            throw new ChatException(ErrorCode400.CHAT_ROOM_USER_CANNOT_DUPLICATE);
+        }
+    }
+
 }

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/enums/ChatMessageType.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/enums/ChatMessageType.java
@@ -1,0 +1,5 @@
+package io.oeid.mogakgo.domain.chat.entity.enums;
+
+public enum ChatMessageType {
+    ENTER, TALK, QUIT
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/entity/enums/ChatStatus.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/entity/enums/ChatStatus.java
@@ -1,0 +1,5 @@
+package io.oeid.mogakgo.domain.chat.entity.enums;
+
+public enum ChatStatus {
+    OPEN, CLOSED
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/exception/ChatException.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/exception/ChatException.java
@@ -1,0 +1,11 @@
+package io.oeid.mogakgo.domain.chat.exception;
+
+import io.oeid.mogakgo.exception.code.ErrorCode;
+import io.oeid.mogakgo.exception.exception_class.CustomException;
+
+public class ChatException extends CustomException {
+
+    public ChatException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/handler/CustomWebSocketHandler.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/handler/CustomWebSocketHandler.java
@@ -1,0 +1,73 @@
+package io.oeid.mogakgo.domain.chat.handler;
+
+import static io.oeid.mogakgo.exception.code.ErrorCode500.CHAT_WEB_SOCKET_ERROR;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.oeid.mogakgo.domain.chat.application.ChatWebSocketService;
+import io.oeid.mogakgo.domain.chat.entity.document.ChatMessage;
+import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
+import io.oeid.mogakgo.domain.chat.exception.ChatException;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomWebSocketHandler implements WebSocketHandler {
+
+    private final ObjectMapper objectMapper;
+    private final ChatWebSocketService chatWebSocketService;
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        log.info("afterConnectionEstablished: {}", session.getId());
+        session.sendMessage(new TextMessage("You are connected to the chat room."));
+    }
+
+    @Override
+    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message)
+        throws Exception {
+        TextMessage textMessage = (TextMessage) message;
+        String payload = textMessage.getPayload();
+        ChatMessage chatMessage = objectMapper.readValue(payload, ChatMessage.class);
+        ChatRoom chatRoom = chatWebSocketService.findChatRoomById(chatMessage.getRoomId());
+        chatWebSocketService.manageChatCollections(chatRoom.getId());
+        sendMessageToEachSocket(chatRoom.getSessions(), textMessage);
+        chatWebSocketService.saveChatMessage(chatMessage, chatRoom.getId());
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception)
+        throws Exception {
+        log.warn("handleTransportError: {}", exception.getMessage());
+        throw new ChatException(CHAT_WEB_SOCKET_ERROR);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
+        throws Exception {
+        log.info("afterConnectionClosed: {}, {}", session.getId(), closeStatus);
+    }
+
+    @Override
+    public boolean supportsPartialMessages() {
+        return false;
+    }
+
+    private void sendMessageToEachSocket(Set<WebSocketSession> sessions, TextMessage message) {
+        sessions.parallelStream().forEach(session -> {
+            try {
+                session.sendMessage(message);
+            } catch (Exception e) {
+                throw new ChatException(CHAT_WEB_SOCKET_ERROR);
+            }
+        });
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/handler/CustomWebSocketHandler.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/handler/CustomWebSocketHandler.java
@@ -35,7 +35,7 @@ public class CustomWebSocketHandler implements WebSocketHandler {
         TextMessage textMessage = (TextMessage) message;
         String payload = textMessage.getPayload();
         ChatMessage chatMessage = objectMapper.readValue(payload, ChatMessage.class);
-        ChatRoom chatRoom = chatWebSocketService.findChatRoomById(chatMessage.getRoomId());
+        ChatRoom chatRoom = chatWebSocketService.findChatRoomById(chatMessage.getChatRoomId());
         switch (chatMessage.getMessageType()) {
             case ENTER -> chatWebSocketService.addSessionToRoom(chatRoom.getId(), session);
             case QUIT -> {

--- a/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRepository.java
@@ -1,0 +1,32 @@
+package io.oeid.mogakgo.domain.chat.infrastructure;
+
+import io.oeid.mogakgo.domain.chat.entity.document.ChatMessage;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public void createCollection(String collectionName) {
+        if (!mongoTemplate.collectionExists(collectionName)) {
+            mongoTemplate.createCollection(collectionName);
+        }
+    }
+
+    public ChatMessage save(ChatMessage chatMessage, String collectionName) {
+        return mongoTemplate.save(chatMessage, collectionName);
+    }
+
+    public List<ChatMessage> findAllByCollection(String collectionName) {
+        Query query = new Query();
+        query.with(Sort.by(Sort.Order.desc("createdAt")));
+        return mongoTemplate.find(query, ChatMessage.class, collectionName);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomCustomRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomCustomRepository.java
@@ -1,0 +1,8 @@
+package io.oeid.mogakgo.domain.chat.infrastructure;
+
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomPublicRes;
+import java.util.List;
+
+public interface ChatRoomCustomRepository {
+    List<ChatRoomPublicRes> findAllChatRoomByUserId(Long userId);
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomCustomRepositoryImpl.java
@@ -1,0 +1,49 @@
+package io.oeid.mogakgo.domain.chat.infrastructure;
+
+import static io.oeid.mogakgo.domain.chat.entity.document.QChatRoom.chatRoom;
+import static io.oeid.mogakgo.domain.user.domain.QUser.user;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomPublicRes;
+import io.oeid.mogakgo.domain.chat.application.vo.ChatUserInfo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<ChatRoomPublicRes> findAllChatRoomByUserId(Long userId) {
+        return jpaQueryFactory.select(
+                Projections.constructor(
+                    ChatRoomPublicRes.class,
+                    chatRoom.project.id,
+                    chatRoom.id,
+                    null,
+                    null,
+                    chatRoom.status,
+                    Projections.list(List.of(
+                            Projections.constructor(
+                                ChatUserInfo.class,
+                                chatRoom.creator.id,
+                                chatRoom.creator.username,
+                                chatRoom.creator.avatarUrl
+                            ),
+                            Projections.constructor(
+                                ChatUserInfo.class,
+                                chatRoom.sender.id,
+                                chatRoom.sender.username,
+                                chatRoom.sender.avatarUrl
+                            )
+                        )
+                    )
+                )
+            ).from(chatRoom).join(chatRoom.creator, user).join(chatRoom.sender, user)
+            .where(chatRoom.creator.id.eq(userId).or(chatRoom.sender.id.eq(userId)))
+            .fetch();
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomJpaRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomJpaRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
+public interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, String> {
 
     @Query("select c from ChatRoom c where c.creator.id = ?1 or c.sender.id = ?1 order by c.id DESC")
     List<ChatRoom> findAllByUserId(Long id);

--- a/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomRepository.java
@@ -1,0 +1,14 @@
+package io.oeid.mogakgo.domain.chat.infrastructure;
+
+import io.oeid.mogakgo.domain.chat.entity.document.ChatRoom;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
+
+    @Query("select c from ChatRoom c where c.creator.id = ?1 or c.sender.id = ?1 order by c.id DESC")
+    List<ChatRoom> findAllByUserId(Long id);
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomRoomJpaRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomRoomJpaRepository.java
@@ -7,7 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, String> {
+public interface ChatRoomRoomJpaRepository extends JpaRepository<ChatRoom, String>,
+    ChatRoomCustomRepository {
 
     @Query("select c from ChatRoom c where c.creator.id = ?1 or c.sender.id = ?1 order by c.id DESC")
     List<ChatRoom> findAllByUserId(Long id);

--- a/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomSessionRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/infrastructure/ChatRoomSessionRepository.java
@@ -1,0 +1,28 @@
+package io.oeid.mogakgo.domain.chat.infrastructure;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.socket.WebSocketSession;
+
+@Repository
+public class ChatRoomSessionRepository {
+    private final Map<String, Set<WebSocketSession>> sessionStorage = new ConcurrentHashMap<>();
+
+    public void addSession(String roomId, WebSocketSession session) {
+        sessionStorage.computeIfAbsent(roomId, key -> ConcurrentHashMap.newKeySet()).add(session);
+    }
+
+    public Set<WebSocketSession> getSession(String roomId) {
+        return sessionStorage.get(roomId);
+    }
+
+    public void removeSession(String roomId, WebSocketSession session) {
+        sessionStorage.get(roomId).remove(session);
+    }
+
+    public void removeRoom(String roomId) {
+        sessionStorage.remove(roomId);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/presentation/ChatController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/presentation/ChatController.java
@@ -1,0 +1,30 @@
+package io.oeid.mogakgo.domain.chat.presentation;
+
+import io.oeid.mogakgo.common.annotation.UserId;
+import io.oeid.mogakgo.domain.chat.application.ChatService;
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomDataRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @GetMapping
+    public void getChatRoomList(@UserId Long userId) {
+        chatService.findAllChatRoomByUserId(userId);
+    }
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ChatRoomDataRes> getChatRoomDetailData(@UserId Long userId,
+        @PathVariable String chatRoomId) {
+        return ResponseEntity.ok(chatService.findAllChatInChatRoom(userId, chatRoomId));
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/chat/presentation/ChatController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/presentation/ChatController.java
@@ -3,6 +3,8 @@ package io.oeid.mogakgo.domain.chat.presentation;
 import io.oeid.mogakgo.common.annotation.UserId;
 import io.oeid.mogakgo.domain.chat.application.ChatService;
 import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomDataRes;
+import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomPublicRes;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,8 +20,8 @@ public class ChatController {
     private final ChatService chatService;
 
     @GetMapping
-    public void getChatRoomList(@UserId Long userId) {
-        chatService.findAllChatRoomByUserId(userId);
+    public ResponseEntity<List<ChatRoomPublicRes>> getChatRoomList(@UserId Long userId) {
+        return ResponseEntity.ok(chatService.findAllChatRoomByUserId(userId));
     }
 
     @GetMapping("/{chatRoomId}")

--- a/src/main/java/io/oeid/mogakgo/domain/chat/presentation/ChatController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/chat/presentation/ChatController.java
@@ -1,6 +1,7 @@
 package io.oeid.mogakgo.domain.chat.presentation;
 
 import io.oeid.mogakgo.common.annotation.UserId;
+import io.oeid.mogakgo.common.swagger.template.ChatSwagger;
 import io.oeid.mogakgo.domain.chat.application.ChatService;
 import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomDataRes;
 import io.oeid.mogakgo.domain.chat.application.dto.res.ChatRoomPublicRes;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chat")
-public class ChatController {
+public class ChatController implements ChatSwagger {
 
     private final ChatService chatService;
 

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
@@ -47,9 +47,9 @@ public enum ErrorCode400 implements ErrorCode {
     INVALID_PROJECT_JOIN_REQUEST_REGION("E090102", "동네 인증한 구역에서만 프로젝트 매칭 요청을 생성할 수 있습니다."),
     PROJECT_JOIN_REQUEST_SHOULD_BE_ONLY_ONE("E090103", "프로젝트 매칭 요청은 한 번에 한 개만 전송할 수 있습니다."),
     INVALID_CREATOR_PROJECT_JOIN_REQUEST("E090104", "프로젝트 생성자는 해당 프로젝트에 매칭 요청을 전송할 수 없습니다."),
-
     MATCHING_CANCEL_NOT_ALLOWED("E090101", "이미 종료되거나 취소된 매칭은 취소할 수 없습니다."),
 
+    CHAT_ROOM_CLOSED("E110101", "채팅방이 종료되어 채팅을 할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
@@ -50,6 +50,7 @@ public enum ErrorCode400 implements ErrorCode {
     MATCHING_CANCEL_NOT_ALLOWED("E090101", "이미 종료되거나 취소된 매칭은 취소할 수 없습니다."),
 
     CHAT_ROOM_CLOSED("E110101", "채팅방이 종료되어 채팅을 할 수 없습니다."),
+    CHAT_ROOM_USER_CANNOT_DUPLICATE("E110102", "채팅방에 중복된 유저가 있습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
@@ -51,6 +51,7 @@ public enum ErrorCode400 implements ErrorCode {
 
     CHAT_ROOM_CLOSED("E110101", "채팅방이 종료되어 채팅을 할 수 없습니다."),
     CHAT_ROOM_USER_CANNOT_DUPLICATE("E110102", "채팅방에 중복된 유저가 있습니다."),
+    CHAT_ROOM_USER_NOT_CONTAINS("E110103", "채팅방에 해당 유저가 없습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode404.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode404.java
@@ -10,6 +10,7 @@ public enum ErrorCode404 implements ErrorCode {
     NOTIFICATION_FCM_TOKEN_NOT_FOUND("E060301", "해당 유저의 FCM 토큰이 존재하지 않습니다."),
     PROJECT_JOIN_REQUEST_NOT_FOUND("E050301", "해당 프로젝트 참여 요청이 존재하지 않습니다."),
     MATCHING_NOT_FOUND("E090301", "해당 매칭이 존재하지 않습니다."),
+    CHAT_ROOM_NOT_FOUND("E110301", "해당 채팅방이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode500.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode500.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode500 implements ErrorCode {
-    INTERNAL_SERVER_ERROR("E999999", "서버에서 알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    INTERNAL_SERVER_ERROR("E999999", "서버에서 알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    CHAT_WEB_SOCKET_ERROR("E110401", "채팅 서버와의 연결이 끊겼습니다."),
+    ;
 
     private final HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
     private final String code;


### PR DESCRIPTION
## 🚀 개발 사항
- WebSocket 활용 채팅 서비스 기초 기능 구현을 완료했습니다.
  - 채팅방 생성, 채팅 보내기
- 채팅 로그 저장을 위한 Mongo DB 설정을 진행했습니다.

### 이슈 번호
- close #145 
- close #146
- close #138 

## 특이 사항 🫶 
- 채팅의 경우 http가 아닌 ws를 사용합니다!
  - `ws://localhost:8080/ws/chat`
- 로컬 테스트는 진행했으나 실제 서버에서의 테스트는 진행해보지 못했습니다!
- 세션 저장을 위한 메모리 레포지토리로 ConcurrentHashMap을 사용했습니다.