### PR TITLE
[REFACT] 프로젝트 카드 랜덤 리스트 조회 API에서 프로젝트 상태 필드를 추가로 전달하도록 수정, queryDSL warn 해결

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -36,7 +36,6 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
         List<Project> entities = jpaQueryFactory.selectFrom(project)
             .innerJoin(project.creator, user)
             .on(project.creator.id.eq(user.id))
-            .join(project.projectTags).fetchJoin()
             .where(
                 cursorIdCondition(pageable.getCursorId()),
                 userIdEq(userId),

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustomImpl.java
@@ -64,6 +64,7 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
                     project.getCreator().getUserWantedJobTags().stream().map(
                         UserWantedJobTag::getWantedJob).map(String::valueOf).toList()
                 ),
+                project.getProjectStatus(),
                 project.getProjectTags().stream().map(ProjectTag::getContent).toList(),
                 new MeetingInfoResponse(
                     project.getMeetingInfo().getMeetStartTime(),

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDetailAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDetailAPIRes.java
@@ -1,5 +1,6 @@
 package io.oeid.mogakgo.domain.project.presentation.dto.res;
 
+import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -15,6 +16,9 @@ public class ProjectDetailAPIRes {
     @Schema(description = "프로젝트 생성자 정보")
     private final UserPublicApiResponse creator;
 
+    @Schema(description = "프로젝트 상태")
+    private final ProjectStatus projectStatus;
+
     @Schema(description = "프로젝트 모임 태그", example = "[\"수다스러운\", \"재밌는\"]")
     private final List<String> projectTags;
 
@@ -23,19 +27,21 @@ public class ProjectDetailAPIRes {
 
 
     public ProjectDetailAPIRes(Long projectId, UserPublicApiResponse creator,
-        List<String> projectTags, MeetingInfoResponse meetingInfo
+        ProjectStatus projectStatus, List<String> projectTags, MeetingInfoResponse meetingInfo
     ) {
         this.projectId = projectId;
         this.creator = creator;
+        this.projectStatus = projectStatus;
         this.projectTags = projectTags;
         this.meetingInfo = meetingInfo;
     }
 
     public static ProjectDetailAPIRes of(Long projectId, UserPublicApiResponse creator,
-        List<String> projectTags, MeetingInfoResponse meetingInfo) {
+        ProjectStatus projectStatus, List<String> projectTags, MeetingInfoResponse meetingInfo) {
         return new ProjectDetailAPIRes(
             projectId,
             creator,
+            projectStatus,
             projectTags,
             meetingInfo
         );

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/infrastructure/ProjectJoinRequestRepositoryCustomImpl.java
@@ -93,7 +93,6 @@ public class ProjectJoinRequestRepositoryCustomImpl implements ProjectJoinReques
         List<ProjectJoinRequestDetailAPIRes> result = entities.stream().map(
             projectJoinRequest -> new ProjectJoinRequestDetailAPIRes(
                     projectJoinRequest.getProject().getId(),
-                    projectJoinRequest.getProject().getProjectStatus(),
                     projectJoinRequest.getProject().getCreator().getAvatarUrl(),
                     new MeetingInfoResponse(
                         projectJoinRequest.getProject().getMeetingInfo().getMeetStartTime(),

--- a/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project_join_req/presentation/dto/res/ProjectJoinRequestDetailAPIRes.java
@@ -1,6 +1,5 @@
 package io.oeid.mogakgo.domain.project_join_req.presentation.dto.res;
 
-import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.MeetingInfoResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -14,29 +13,24 @@ public class ProjectJoinRequestDetailAPIRes {
     @NotNull
     private final Long projectId;
 
-    @Schema(description = "프로젝트 상태", example = "PENDING", implementation = ProjectStatus.class)
-    @NotNull
-    private final ProjectStatus projectStatus;
-
     @Schema(description = "프로젝트 생성자 아바타 URL", example = "https://avatars.githubusercontent.com/u/85854384?v=4")
     private final String creatorAvatorUrl;
 
     @Schema(description = "프로젝트 만남 장ㅔ")
     private final MeetingInfoResponse meetingInfo;
 
-    public ProjectJoinRequestDetailAPIRes(Long projectId, ProjectStatus projectStatus,
-        String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    public ProjectJoinRequestDetailAPIRes(Long projectId, String creatorAvatorUrl,
+        MeetingInfoResponse meetingInfo
     ) {
         this.projectId = projectId;
-        this.projectStatus = projectStatus;
         this.creatorAvatorUrl = creatorAvatorUrl;
         this.meetingInfo = meetingInfo;
     }
 
-    public static ProjectJoinRequestDetailAPIRes from(Long projectId, ProjectStatus projectStatus,
-        String creatorAvatorUrl, MeetingInfoResponse meetingInfo
+    public static ProjectJoinRequestDetailAPIRes from(Long projectId, String creatorAvatorUrl,
+        MeetingInfoResponse meetingInfo
     ) {
-        return new ProjectJoinRequestDetailAPIRes(projectId, projectStatus, creatorAvatorUrl, meetingInfo);
+        return new ProjectJoinRequestDetailAPIRes(projectId, creatorAvatorUrl, meetingInfo);
     }
 
 }


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 프로젝트 매칭 요청 API 응답에서 `projectStatus` 제거
- [x] 프로젝트 리스트 조회 API 응답에서 `projectStatus` 추가
- [x] fetchJoin과 pagination 동시 사용으로 인한 queryDsl warn 해결 

### 이슈 번호
- close #173 

## 특이 사항 🫶 
