### PR TITLE
[FEAT] 사용자의 대표 업적 변경 API 기능 개발

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/UserSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/UserSwagger.java
@@ -2,10 +2,14 @@ package io.oeid.mogakgo.common.swagger.template;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import io.oeid.mogakgo.core.properties.swagger.error.SwaggerAchievementErrorExamples;
+import io.oeid.mogakgo.core.properties.swagger.error.SwaggerUserAchievementErrorExamples;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerUserErrorExamples;
 import io.oeid.mogakgo.domain.user.application.dto.res.UserJandiRateRes;
+import io.oeid.mogakgo.domain.user.presentation.dto.req.UserAchievementUpdateApiRequest;
 import io.oeid.mogakgo.domain.user.presentation.dto.req.UserSignUpApiReq;
 import io.oeid.mogakgo.domain.user.presentation.dto.req.UserUpdateApiReq;
+import io.oeid.mogakgo.domain.user.presentation.dto.res.UserAchievementUpdateApiResponse;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserDevelopLanguageApiRes;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserMatchingStatus;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
@@ -124,5 +128,37 @@ public interface UserSwagger {
                 examples = @ExampleObject(name = "E020301", value = SwaggerUserErrorExamples.USER_NOT_FOUND))),
     })
     ResponseEntity<UserJandiRateRes> userJandiRateApi(@Parameter(in = ParameterIn.PATH) Long userId);
-  
+
+    @Operation(summary = "사용자의 대표 업적 변경", description = "사용자가 자신의 대표 업적을 변경하고 싶을 때 사용하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "대표 업적 변경 성공"),
+        @ApiResponse(responseCode = "400", description = "요청한 데이터가 유효하지 않음",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(name = "E140101", value = SwaggerUserAchievementErrorExamples.NON_ACHIEVED_USER_ACHIEVEMENT),
+                    @ExampleObject(name = "E140102", value = SwaggerUserAchievementErrorExamples.ACHIEVEMENT_SHOULD_BE_DIFFERENT)
+                }
+            )),
+        @ApiResponse(responseCode = "403", description = "사용자의 대표 업적을 변경할 권한이 없음",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E020201", value = SwaggerUserErrorExamples.USER_FORBIDDEN_OPERATION)
+            )),
+        @ApiResponse(responseCode = "404", description = "요청한 데이터가 존재하지 않음",
+            content = @Content(
+                mediaType = APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = {
+                    @ExampleObject(name = "E130301", value = SwaggerAchievementErrorExamples.ACHIEVEMENT_NOT_FOUND),
+                    @ExampleObject(name = "E020301", value = SwaggerUserErrorExamples.USER_NOT_FOUND)
+                }
+            ))
+    })
+    ResponseEntity<UserAchievementUpdateApiResponse> updateUserMainAchievement(
+        @Parameter(hidden = true) Long userId,
+        UserAchievementUpdateApiRequest request
+    );
 }

--- a/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerAchievementErrorExamples.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerAchievementErrorExamples.java
@@ -1,0 +1,9 @@
+package io.oeid.mogakgo.core.properties.swagger.error;
+
+public class SwaggerAchievementErrorExamples {
+
+    public static final String ACHIEVEMENT_NOT_FOUND = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":404,\"code\":\"E130301\",\"message\":\"해당 업적이 존재하지 않습니다.\"}";
+    private SwaggerAchievementErrorExamples() {
+
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerUserAchievementErrorExamples.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerUserAchievementErrorExamples.java
@@ -1,0 +1,12 @@
+package io.oeid.mogakgo.core.properties.swagger.error;
+
+public class SwaggerUserAchievementErrorExamples {
+
+    public static final String NON_ACHIEVED_USER_ACHIEVEMENT = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E140101\",\"message\":\"대표 업적으로 미달성 업적을 사용할 수 없습니다.\"}";
+    public static final String ACHIEVEMENT_SHOULD_BE_DIFFERENT = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E140102\",\"message\":\"해당 업적을 이미 대표 업적으로 사용하고 있습니다.\"}";
+
+    private SwaggerUserAchievementErrorExamples() {
+
+    }
+
+}

--- a/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerUserErrorExamples.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/swagger/error/SwaggerUserErrorExamples.java
@@ -8,6 +8,7 @@ public class SwaggerUserErrorExamples {
     public static final String USER_AVAILABLE_LIKE_COUNT_IS_ZERO = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E020107\",\"message\":\"당일 사용 가능한 찔러보기 요청을 모두 소진했습니다.\"}";
     public static final String USER_AVAILABLE_LIKE_COUNT_IS_FULL = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E020108\",\"message\":\"당일 사용 가능한 찔러보기 최대 요청 횟수를 초과활 수 없습니다.\"}";
     public static final String USER_AVATAR_URL_NOT_NULL = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":400,\"code\":\"E020109\",\"message\":\"유저 프로필 이미지는 비어있을 수 없습니다.\"}";
+    public static final String USER_FORBIDDEN_OPERATION = "{\"timestamp\":\"2024-02-17T10:07:31.404Z\",\"statusCode\":403,\"code\":\"E020201\",\"message\":\"사용자의 정보를 변경할 권한이 없습니다.\"}";
     private SwaggerUserErrorExamples() {
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/domain/entity/UserAchievement.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/domain/entity/UserAchievement.java
@@ -22,7 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Entity
-@Table(name = "user_achievement_mapping_tb")
+@Table(name = "user_achievement_tb")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class UserAchievement {

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/domain/entity/UserAchievement.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/domain/entity/UserAchievement.java
@@ -1,5 +1,8 @@
 package io.oeid.mogakgo.domain.achievement.domain.entity;
 
+import static io.oeid.mogakgo.exception.code.ErrorCode400.NON_ACHIEVED_USER_ACHIEVEMENT;
+
+import io.oeid.mogakgo.domain.achievement.exception.UserAchievementException;
 import io.oeid.mogakgo.domain.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,7 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Entity
-@Table(name = "user_achievement_tb")
+@Table(name = "user_achievement_mapping_tb")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class UserAchievement {
@@ -47,5 +50,11 @@ public class UserAchievement {
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
+
+    public void validateAvailableUpdateAchievement() {
+        if (this.completed.equals(Boolean.FALSE)) {
+            throw new UserAchievementException(NON_ACHIEVED_USER_ACHIEVEMENT);
+        }
+    }
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/exception/AchievementException.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/exception/AchievementException.java
@@ -1,0 +1,11 @@
+package io.oeid.mogakgo.domain.achievement.exception;
+
+import io.oeid.mogakgo.exception.code.ErrorCode;
+import io.oeid.mogakgo.exception.exception_class.CustomException;
+
+public class AchievementException extends CustomException {
+
+    public AchievementException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/exception/UserAchievementException.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/exception/UserAchievementException.java
@@ -1,0 +1,11 @@
+package io.oeid.mogakgo.domain.achievement.exception;
+
+import io.oeid.mogakgo.exception.code.ErrorCode;
+import io.oeid.mogakgo.exception.exception_class.CustomException;
+
+public class UserAchievementException extends CustomException {
+
+    public UserAchievementException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementJpaRepository.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementJpaRepository.java
@@ -1,0 +1,12 @@
+package io.oeid.mogakgo.domain.achievement.infrastructure;
+
+import io.oeid.mogakgo.domain.achievement.domain.entity.UserAchievement;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserAchievementJpaRepository extends JpaRepository<UserAchievement, Long> {
+
+    @Query("SELECT ua FROM UserAchievement ua WHERE ua.user.id = :userId AND ua.achievement.id = :achievementId")
+    Optional<UserAchievement> findByUserAndAchievementId(Long userId, Long achievementId);
+}

--- a/src/main/java/io/oeid/mogakgo/domain/user/application/dto/res/UserUpdateRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/application/dto/res/UserUpdateRes.java
@@ -15,15 +15,13 @@ public class UserUpdateRes {
     private String bio;
     private String avatarUrl;
     private List<WantedJob> wantedJobs;
-    private Long achievementId;
 
     public static UserUpdateRes from(User user){
         return new UserUpdateRes(
             user.getUsername(),
             user.getBio(),
             user.getAvatarUrl(),
-            user.getUserWantedJobTags().stream().map(UserWantedJobTag::getWantedJob).toList(),
-            user.getAchievement().getId()
+            user.getUserWantedJobTags().stream().map(UserWantedJobTag::getWantedJob).toList()
         );
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/user/domain/User.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/domain/User.java
@@ -1,9 +1,12 @@
 package io.oeid.mogakgo.domain.user.domain;
 
+import static io.oeid.mogakgo.exception.code.ErrorCode400.ACHIEVEMENT_SHOULD_BE_DIFFERENT;
 import static io.oeid.mogakgo.exception.code.ErrorCode400.USER_AVAILABLE_LIKE_AMOUNT_IS_FULL;
 import static io.oeid.mogakgo.exception.code.ErrorCode400.USER_AVAILABLE_LIKE_COUNT_IS_ZERO;
+import static io.oeid.mogakgo.exception.code.ErrorCode403.USER_FORBIDDEN_OPERATION;
 
 import io.oeid.mogakgo.domain.achievement.domain.entity.Achievement;
+import io.oeid.mogakgo.domain.achievement.exception.UserAchievementException;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
 import io.oeid.mogakgo.domain.review.domain.enums.ReviewRating;
 import io.oeid.mogakgo.domain.user.domain.enums.Role;
@@ -205,13 +208,18 @@ public class User {
         }
     }
 
-    public void updateUserInfos(String username, String avatarUrl, String bio,
-        Achievement achievement) {
+    public void updateUserInfos(String username, String avatarUrl, String bio) {
         updateUsername(username);
         this.avatarUrl = verifyAvatarUrl(avatarUrl);
         this.bio = bio;
-        this.achievement = achievement;
         deleteAllWantJobTags();
+    }
+
+    public void updateAchievement(Achievement achievement) {
+        if (this.achievement != null && this.achievement.equals(achievement)) {
+            throw new UserAchievementException(ACHIEVEMENT_SHOULD_BE_DIFFERENT);
+        }
+        this.achievement = achievement;
     }
 
     public void updateJandiRateByReview(ReviewRating rating, double time) {
@@ -233,5 +241,10 @@ public class User {
         return avatarUrl;
     }
 
+    public void validateUpdater(Long userId) {
+        if (!this.id.equals(userId)) {
+            throw new UserException(USER_FORBIDDEN_OPERATION);
+        }
+    }
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/user/presentation/UserController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/presentation/UserController.java
@@ -6,8 +6,10 @@ import io.oeid.mogakgo.domain.matching.application.UserMatchingService;
 import io.oeid.mogakgo.domain.user.application.UserService;
 import io.oeid.mogakgo.domain.user.application.dto.req.UserUpdateReq;
 import io.oeid.mogakgo.domain.user.application.dto.res.UserJandiRateRes;
+import io.oeid.mogakgo.domain.user.presentation.dto.req.UserAchievementUpdateApiRequest;
 import io.oeid.mogakgo.domain.user.presentation.dto.req.UserSignUpApiReq;
 import io.oeid.mogakgo.domain.user.presentation.dto.req.UserUpdateApiReq;
+import io.oeid.mogakgo.domain.user.presentation.dto.res.UserAchievementUpdateApiResponse;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserDevelopLanguageApiRes;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserMatchingStatus;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
@@ -76,5 +78,13 @@ public class UserController implements UserSwagger {
     public ResponseEntity<UserMatchingStatus> userMatchingStatusApi(@UserId Long userId) {
         return ResponseEntity.ok(
             new UserMatchingStatus(userMatchingService.hasProgressMatching(userId)));
+    }
+
+    @PatchMapping("/achievement")
+    public ResponseEntity<UserAchievementUpdateApiResponse> updateUserMainAchievement(
+        @UserId Long userId, @Valid @RequestBody UserAchievementUpdateApiRequest request
+    ) {
+        Long id = userService.updateAchievement(userId, request);
+        return ResponseEntity.ok().body(UserAchievementUpdateApiResponse.from(id));
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/req/UserAchievementUpdateApiRequest.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/req/UserAchievementUpdateApiRequest.java
@@ -1,0 +1,26 @@
+package io.oeid.mogakgo.domain.user.presentation.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "사용자의 대표 업적 수정 요청 DTO")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserAchievementUpdateApiRequest {
+
+    @Schema(description = "대표 업적을 수정하려는 사용자 ID", example = "11", implementation = Long.class)
+    @NotNull
+    private final Long userId;
+
+    @Schema(description = "수정하려는 대표 업적 ID", example = "2", implementation = Long.class)
+    @NotNull
+    private final Long achievementId;
+
+    public static UserAchievementUpdateApiRequest of(Long userId, Long achievementId) {
+        return new UserAchievementUpdateApiRequest(userId, achievementId);
+    }
+
+}

--- a/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserAchievementUpdateApiResponse.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserAchievementUpdateApiResponse.java
@@ -1,0 +1,21 @@
+package io.oeid.mogakgo.domain.user.presentation.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "사용자의 대표 업적 수정 요청의 응답 DTO")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserAchievementUpdateApiResponse {
+
+    @Schema(description = "대표 업적을 수정한 사용자 ID", example = "11", implementation = Long.class)
+    @NotNull
+    private final Long userId;
+
+    public static UserAchievementUpdateApiResponse from(Long userId) {
+        return new UserAchievementUpdateApiResponse(userId);
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserUpdateApiRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserUpdateApiRes.java
@@ -23,16 +23,13 @@ public class UserUpdateApiRes {
     private String avatarUrl;
     @Schema(description = "유저가 원하는 직군", example = "[\"BACKEND\", \"FRONTEND\"]")
     private List<String> wantedJobs;
-    @Schema(description = "유저의 업적 ID", example = "1")
-    private Long achievementId;
 
     public static UserUpdateApiRes from(UserUpdateRes userUpdateRes) {
         return new UserUpdateApiRes(
             userUpdateRes.getUsername(),
             userUpdateRes.getBio(),
             userUpdateRes.getAvatarUrl(),
-            userUpdateRes.getWantedJobs().stream().map(WantedJob::getJobName).toList(),
-            userUpdateRes.getAchievementId()
+            userUpdateRes.getWantedJobs().stream().map(WantedJob::getJobName).toList()
         );
     }
 }

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
@@ -62,8 +62,8 @@ public enum ErrorCode400 implements ErrorCode {
     REVIEW_PROJECT_NOT_NULL("E120103", "리뷰를 작성하기 위한 프로젝트 정보가 존재하지 않습니다."),
     REVIEW_ALREADY_EXISTS("E120104", "이미 작성된 리뷰가 존재합니다."),
 
-    NON_ACHIEVED_USER_ACHIEVEMENT("E130101", "미달성 업적을 사용할 수 없습니다."),
-    ACHIEVEMENT_SHOULD_BE_DIFFERENT("E130102", "이미 해당 업적을 대표 업적으로 사용중입니다."),
+    NON_ACHIEVED_USER_ACHIEVEMENT("E140101", "미달성 업적을 사용할 수 없습니다."),
+    ACHIEVEMENT_SHOULD_BE_DIFFERENT("E140102", "이미 해당 업적을 대표 업적으로 사용중입니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode400.java
@@ -61,6 +61,9 @@ public enum ErrorCode400 implements ErrorCode {
     REVIEW_USER_DUPLICATED("E120102", "자신에 대한 리뷰는 작성할 수 없습니다."),
     REVIEW_PROJECT_NOT_NULL("E120103", "리뷰를 작성하기 위한 프로젝트 정보가 존재하지 않습니다."),
     REVIEW_ALREADY_EXISTS("E120104", "이미 작성된 리뷰가 존재합니다."),
+
+    NON_ACHIEVED_USER_ACHIEVEMENT("E130101", "미달성 업적을 사용할 수 없습니다."),
+    ACHIEVEMENT_SHOULD_BE_DIFFERENT("E130102", "이미 해당 업적을 대표 업적으로 사용중입니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode403.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode403.java
@@ -11,7 +11,7 @@ public enum ErrorCode403 implements ErrorCode {
     INVALID_CERT_INFORMATION("E070201", "동네 인증을 수행할 권한이 없습니다."),
     PROFILE_CARD_LIKE_FORBIDDEN_OPERATION("E040101", "본인 프로필 카드의 좋아요 수만 조회할 수 있습니다."),
     MATCHING_FORBIDDEN_OPERATION("E090201", "해당 매칭에 대한 권한이 없습니다."),
-    USER_FORBIDDEN_OPERATION("E20201", "사용자 정보를 수정할 권한이 없습니다."),
+    USER_FORBIDDEN_OPERATION("E020201", "사용자 정보를 수정할 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.FORBIDDEN;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode403.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode403.java
@@ -11,6 +11,7 @@ public enum ErrorCode403 implements ErrorCode {
     INVALID_CERT_INFORMATION("E070201", "동네 인증을 수행할 권한이 없습니다."),
     PROFILE_CARD_LIKE_FORBIDDEN_OPERATION("E040101", "본인 프로필 카드의 좋아요 수만 조회할 수 있습니다."),
     MATCHING_FORBIDDEN_OPERATION("E090201", "해당 매칭에 대한 권한이 없습니다."),
+    USER_FORBIDDEN_OPERATION("E20201", "사용자 정보를 수정할 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.FORBIDDEN;

--- a/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode404.java
+++ b/src/main/java/io/oeid/mogakgo/exception/code/ErrorCode404.java
@@ -12,6 +12,7 @@ public enum ErrorCode404 implements ErrorCode {
     PROJECT_JOIN_REQUEST_NOT_FOUND("E050301", "해당 프로젝트 참여 요청이 존재하지 않습니다."),
     MATCHING_NOT_FOUND("E090301", "해당 매칭이 존재하지 않습니다."),
     CHAT_ROOM_NOT_FOUND("E110301", "해당 채팅방이 존재하지 않습니다."),
+    ACHIEVEMENT_NOT_FOUND("E130301", "해당 업적이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자의 대표 업적 변경 API 기능 개발
- [x] 대표 업적 변경 API 관련 Swagger 작성

### 이슈 번호
- close #137 

## 특이 사항 🫶 
- 사용자가 대표 업적을 변경하는 과정에서, 이미 대표 업적으로 등록되어 있는 업적을 동일하게 변경하려고 할 때 어떤 식으로 처리를 하는 것이 좋을지 고민이 됩니다.
1. User 엔티티의 잦은 변경을 막기 위해 400 에러 발생
2. User 엔티티의 변경은 막되, 에러 발생과 실제 변경 없이 성공 반환
3. 요청이 들어올 때마다 그냥 변경

일단은 1번으로 구현을 해놓은 상황인데 더 좋은 아이디어나 이유가 있다면 코멘트 부탁드립니다!