### PR TITLE
[REFACT] 프로젝트, 프로필 카드 리스트 정렬 시, 마지막 원소를 제외하고 랜덤 정렬하도록 수정

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -44,7 +44,7 @@ public class ProfileCardService {
             null, region, pageable
         );
 
-        Collections.shuffle(profiles.getData());
+        Collections.shuffle(profiles.getData().subList(0, profiles.getData().size() - 1));
         return profiles;
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
@@ -147,7 +147,7 @@ public class ProjectService {
         );
 
         // 요청할 때마다 랜덤 정렬
-        Collections.shuffle(projects.getData());
+        Collections.shuffle(projects.getData().subList(0, projects.getData().size() - 1));
         return projects;
     }
 


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 프로젝트, 프로필 카드 리스트 랜덤 조회 시, 커서 기반 페이지네이션을 위해 마지막 원소를 제외하고 랜덤 정렬하도록 수정

### 이슈 번호
- close #199 

## 특이 사항 🫶 
