### PR TITLE
[FEAT] 테스트용 유저 인증 어노테이션 구현

### DIFF
--- a/src/main/java/io/oeid/mogakgo/core/properties/JwtProperties.java
+++ b/src/main/java/io/oeid/mogakgo/core/properties/JwtProperties.java
@@ -1,6 +1,5 @@
 package io.oeid.mogakgo.core.properties;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Getter
 @Component
 @ConfigurationProperties(prefix = "jwt")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class JwtProperties {
 
     private String header;

--- a/src/test/java/io/oeid/mogakgo/core/support/WithMockCustomUser.java
+++ b/src/test/java/io/oeid/mogakgo/core/support/WithMockCustomUser.java
@@ -1,0 +1,11 @@
+package io.oeid.mogakgo.core.support;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    long userId() default 1L;
+}

--- a/src/test/java/io/oeid/mogakgo/core/support/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/io/oeid/mogakgo/core/support/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,44 @@
+package io.oeid.mogakgo.core.support;
+
+import io.oeid.mogakgo.core.properties.JwtProperties;
+import io.oeid.mogakgo.domain.auth.jwt.JwtAuthenticationToken;
+import io.oeid.mogakgo.domain.auth.jwt.JwtHelper;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCustomUser> {
+
+    private static JwtProperties initProperties() {
+        JwtProperties properties = new JwtProperties();
+        properties.setHeader("test");
+        properties.setIssuer("test");
+        properties.setClientSecret("test");
+        properties.setAccessTokenExpiryHour(1);
+        properties.setRefreshTokenExpiryHour(3);
+        return properties;
+    }
+
+    private final JwtHelper jwtHelper;
+
+    public WithMockCustomUserSecurityContextFactory() {
+        this.jwtHelper = new JwtHelper(
+            initProperties()
+        );
+    }
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser mockCustomUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        var token = jwtHelper.sign(mockCustomUser.userId(),
+            authorities.stream().map(GrantedAuthority::getAuthority).toArray(String[]::new));
+        var auth = new JwtAuthenticationToken(token, null, authorities);
+        context.setAuthentication(auth);
+        return context;
+    }
+}


### PR DESCRIPTION
## 🚀 개발 사항
- 테스트용 유저 어노테이션을 구현했습니다.
  - `@WithMockCustomUser`을 사용하면 테스트에서 인증이 가능합니다!
### 이슈 번호
- close #203 

## 특이 사항 🫶 
- 컨트롤러 테스트를 작성할때 `.with(csrf())`를 꼭 작성해줘야합니다! 작성하지 않으면 어노테이션이 작동하지 않아요..