### PR TITLE
[BUG] 프로젝트, 프로필 카드 리스트 랜덤 정렬 시, 2개 이하의 리스트에 대해 발생하는 예외 처리

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -44,7 +44,9 @@ public class ProfileCardService {
             null, region, pageable
         );
 
-        Collections.shuffle(profiles.getData().subList(0, profiles.getData().size() - 1));
+        if (profiles.getData().size() >= 2) {
+            Collections.shuffle(profiles.getData().subList(0, profiles.getData().size() - 1));
+        }
         return profiles;
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
@@ -147,7 +147,9 @@ public class ProjectService {
         );
 
         // 요청할 때마다 랜덤 정렬
-        Collections.shuffle(projects.getData().subList(0, projects.getData().size() - 1));
+        if (projects.getData().size() >= 2) {
+            Collections.shuffle(projects.getData().subList(0, projects.getData().size() - 1));
+        }
         return projects;
     }
 


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 프로젝트, 프로필 카드 리스트 정렬 시, 2개 이하의 리스트에 대한 예외 처리 구현

### 이슈 번호
- close #208 

## 특이 사항 🫶 
