### PR TITLE
[REFACT] 선택한 구역에 대한 프로필 카드 리스트 조회 API 리팩토링

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ProfileCardSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ProfileCardSwagger.java
@@ -5,7 +5,7 @@ import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerGeoErrorExamples;
 import io.oeid.mogakgo.core.properties.swagger.error.SwaggerUserErrorExamples;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
-import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
+import io.oeid.mogakgo.domain.profile.presentation.dto.res.UserProfileInfoAPIRes;
 import io.oeid.mogakgo.exception.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,7 +42,7 @@ public interface ProfileCardSwagger {
         @Parameter(name = "pageSize", description = "요청할 데이터 크기", example = "5", required = true),
         @Parameter(name = "sortOrder", description = "정렬 방향", example = "ASC"),
     })
-    ResponseEntity<CursorPaginationResult<UserPublicApiResponse>> getRandomOrderedProfileCardsByRegion(
+    ResponseEntity<CursorPaginationResult<UserProfileInfoAPIRes>> getRandomOrderedProfileCardsByRegion(
         @Parameter(hidden = true) Long userId,
         @Parameter(description = "조회하려는 서비스 지역", required = true) Region region,
         @Parameter(hidden = true) CursorPaginationInfoReq pageable

--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -9,9 +9,9 @@ import io.oeid.mogakgo.domain.geo.exception.GeoException;
 import io.oeid.mogakgo.domain.profile.application.dto.req.UserProfileCardReq;
 import io.oeid.mogakgo.domain.profile.domain.entity.ProfileCard;
 import io.oeid.mogakgo.domain.profile.infrastructure.ProfileCardJpaRepository;
+import io.oeid.mogakgo.domain.profile.presentation.dto.res.UserProfileInfoAPIRes;
 import io.oeid.mogakgo.domain.user.application.UserCommonService;
 import io.oeid.mogakgo.domain.user.domain.User;
-import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,15 +33,15 @@ public class ProfileCardService {
         return profileCard.getId();
     }
 
-    public CursorPaginationResult<UserPublicApiResponse> getRandomOrderedProfileCardsByRegion(
+    public CursorPaginationResult<UserProfileInfoAPIRes> getRandomOrderedProfileCardsByRegion(
         Long userId, Region region, CursorPaginationInfoReq pageable
     ) {
         validateToken(userId);
         validateRegionCoverage(region);
 
-        CursorPaginationResult<UserPublicApiResponse> profiles = profileCardRepository
+        CursorPaginationResult<UserProfileInfoAPIRes> profiles = profileCardRepository
             .findByConditionWithPagination(
-            null, region, pageable
+            userId, region, pageable
         );
 
         if (profiles.getData().size() >= 2) {

--- a/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustom.java
@@ -3,11 +3,11 @@ package io.oeid.mogakgo.domain.profile.infrastructure;
 import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
-import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
+import io.oeid.mogakgo.domain.profile.presentation.dto.res.UserProfileInfoAPIRes;
 
 public interface ProfileCardRepositoryCustom {
 
-    CursorPaginationResult<UserPublicApiResponse> findByConditionWithPagination(
+    CursorPaginationResult<UserProfileInfoAPIRes> findByConditionWithPagination(
         Long userId, Region region, CursorPaginationInfoReq pageable
     );
 }

--- a/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package io.oeid.mogakgo.domain.profile.infrastructure;
 
 import static io.oeid.mogakgo.domain.profile.domain.entity.QProfileCard.profileCard;
+import static io.oeid.mogakgo.domain.profile.domain.entity.QProfileCardLike.profileCardLike;
 import static io.oeid.mogakgo.domain.user.domain.QUser.user;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -9,10 +10,13 @@ import io.oeid.mogakgo.common.base.CursorPaginationInfoReq;
 import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
 import io.oeid.mogakgo.domain.profile.domain.entity.ProfileCard;
+import io.oeid.mogakgo.domain.profile.domain.entity.ProfileCardLike;
+import io.oeid.mogakgo.domain.profile.presentation.dto.res.UserProfileInfoAPIRes;
 import io.oeid.mogakgo.domain.user.domain.UserDevelopLanguageTag;
 import io.oeid.mogakgo.domain.user.domain.UserWantedJobTag;
 import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -23,15 +27,16 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public CursorPaginationResult<UserPublicApiResponse> findByConditionWithPagination(
+    public CursorPaginationResult<UserProfileInfoAPIRes> findByConditionWithPagination(
         Long userId, Region region, CursorPaginationInfoReq pageable
     ) {
+
         List<ProfileCard> entities = jpaQueryFactory.selectFrom(profileCard)
             .innerJoin(profileCard.user, user)
             .on(profileCard.user.id.eq(user.id))
             .where(
                 cursorIdCondition(pageable.getCursorId()),
-                userIdEq(userId),
+                excludeUserId(userId),
                 regionEq(region),
                 deletedProfileCardEq()
             )
@@ -40,20 +45,24 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
             .limit(pageable.getPageSize() + 1)
             .fetch();
 
-        List<UserPublicApiResponse> result = entities.stream().map(
-            profileCard -> new UserPublicApiResponse(
-                profileCard.getUser().getId(),
-                profileCard.getUser().getUsername(),
-                profileCard.getUser().getGithubId(),
-                profileCard.getUser().getAvatarUrl(),
-                profileCard.getUser().getGithubUrl(),
-                profileCard.getUser().getBio(),
-                profileCard.getUser().getJandiRate(),
-                profileCard.getUser().getAchievement() != null ? profileCard.getUser().getAchievement().getTitle() : null,
-                profileCard.getUser().getUserDevelopLanguageTags().stream().map(
-                    UserDevelopLanguageTag::getDevelopLanguage).map(String::valueOf).toList(),
-                profileCard.getUser().getUserWantedJobTags().stream().map(
-                    UserWantedJobTag::getWantedJob).map(String::valueOf).toList()
+        List<UserProfileInfoAPIRes> result = entities.stream().map(
+            profileCard -> new UserProfileInfoAPIRes(
+                new UserPublicApiResponse(
+                    profileCard.getUser().getId(),
+                    profileCard.getUser().getUsername(),
+                    profileCard.getUser().getGithubId(),
+                    profileCard.getUser().getAvatarUrl(),
+                    profileCard.getUser().getGithubUrl(),
+                    profileCard.getUser().getBio(),
+                    profileCard.getUser().getJandiRate(),
+                    profileCard.getUser().getAchievement() != null ? profileCard.getUser().getAchievement().getTitle() : null,
+                    profileCard.getUser().getUserDevelopLanguageTags().stream().map(
+                        UserDevelopLanguageTag::getDevelopLanguage).map(String::valueOf).toList(),
+                    profileCard.getUser().getUserWantedJobTags().stream().map(
+                        UserWantedJobTag::getWantedJob).map(String::valueOf).toList()
+                ),
+                findProfileCardLikeBySenderId(profileCard.getUser().getId(), userId)
+                    .isPresent() ? Boolean.TRUE : Boolean.FALSE
             )
         ).toList();
 
@@ -62,16 +71,26 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
         );
     }
 
+    private Optional<ProfileCardLike> findProfileCardLikeBySenderId(Long receiverId, Long userId) {
+        return Optional.ofNullable(jpaQueryFactory.selectFrom(profileCardLike)
+            .join(profileCardLike.receiver)
+            .where(
+                profileCardLike.receiver.id.eq(receiverId),
+                profileCardLike.sender.id.eq(userId)
+            )
+            .fetchOne());
+    }
+
     private BooleanExpression regionEq(Region region) {
         return region != null ? profileCard.user.region.eq(region) : null;
     }
 
-    private BooleanExpression userIdEq(Long userId) {
-        return userId != null ? profileCard.user.id.eq(userId) : null;
-    }
-
     private BooleanExpression cursorIdCondition(Long cursorId) {
         return cursorId != null ? profileCard.id.lt(cursorId) : null;
+    }
+
+    private BooleanExpression excludeUserId(Long userId) {
+        return profileCard.user.id.ne(userId);
     }
 
     private BooleanExpression deletedProfileCardEq() {

--- a/src/main/java/io/oeid/mogakgo/domain/profile/presentation/ProfileCardController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/presentation/ProfileCardController.java
@@ -6,7 +6,7 @@ import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.common.swagger.template.ProfileCardSwagger;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
 import io.oeid.mogakgo.domain.profile.application.ProfileCardService;
-import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
+import io.oeid.mogakgo.domain.profile.presentation.dto.res.UserProfileInfoAPIRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +24,7 @@ public class ProfileCardController implements ProfileCardSwagger {
     private final ProfileCardService profileCardService;
 
     @GetMapping("/{region}")
-    public ResponseEntity<CursorPaginationResult<UserPublicApiResponse>> getRandomOrderedProfileCardsByRegion(
+    public ResponseEntity<CursorPaginationResult<UserProfileInfoAPIRes>> getRandomOrderedProfileCardsByRegion(
         @UserId Long userId, @PathVariable Region region,
         @Valid @ModelAttribute CursorPaginationInfoReq pageable
     ) {

--- a/src/main/java/io/oeid/mogakgo/domain/profile/presentation/dto/res/UserProfileInfoAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/presentation/dto/res/UserProfileInfoAPIRes.java
@@ -1,0 +1,19 @@
+package io.oeid.mogakgo.domain.profile.presentation.dto.res;
+
+import io.oeid.mogakgo.domain.user.presentation.dto.res.UserPublicApiResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "선택한 구역에 대한 프로필 카드 리스트 조회 응답 DTO")
+@Getter
+@AllArgsConstructor
+public class UserProfileInfoAPIRes {
+
+    @Schema(description = "조회하는 프로필 카드의 상세 정보")
+    private final UserPublicApiResponse response;
+
+    @Schema(description = "해당 프로필 카드에 대해 사용자의 '찔러보기' 요청 여부")
+    private final Boolean requestYn;
+
+}


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자는 자신이 인증한 구역에서 자신의 프로필 카드를 볼 수 없도록 수정
- [x] 프로필 카드 리스트 조회 시, 해당 프로필 카드에 사용자가 '찔러보기' 요청을 보냈는지의 여부를 같이 전달하도록 추가

### 이슈 번호
- close #216 

## 특이 사항 🫶 
