### PR TITLE
[FEAT] 사용자가 생성한 최신 프로젝트 상세 조회 API 개발

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
+++ b/src/main/java/io/oeid/mogakgo/common/swagger/template/ProjectSwagger.java
@@ -9,6 +9,7 @@ import io.oeid.mogakgo.domain.geo.domain.enums.Region;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDensityRankRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailInfoAPIRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectIdRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectInfoAPIRes;
 import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestRes;
@@ -227,6 +228,25 @@ public interface ProjectSwagger {
     ResponseEntity<ProjectDetailAPIRes> getById(
         @Parameter(hidden = true) Long userId,
         @Parameter(description = "조회하려는 프로젝트 ID", required = true) Long projectId,
+        @Parameter(description = "프로젝트 생성자 ID", required = true) Long id
+    );
+
+    @Operation(summary = "사용자의 최근 생성 프로젝트 상세 정보 조회", description = "회원이 자신이 생성한 최신 프로젝트의 상세 정보를 조회할 때 사용하는 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "프로젝트 조회 성공"),
+        @ApiResponse(responseCode = "403", description = "본인의 프로젝트 카드만 조회 할 수 있음.",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E030101", value = SwaggerProjectErrorExamples.PROJECT_JOIN_REQUEST_FORBIDDEN_OPERATION))),
+        @ApiResponse(responseCode = "404", description = "요청한 데이터가 존재하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(name = "E020301", value = SwaggerUserErrorExamples.USER_NOT_FOUND)))
+    })
+    ResponseEntity<ProjectDetailInfoAPIRes> getByUserId(
+        @Parameter(hidden = true) Long userId,
         @Parameter(description = "프로젝트 생성자 ID", required = true) Long id
     );
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
@@ -179,6 +179,14 @@ public class ProjectService {
         return new ProjectDensityRankRes(regionRankList);
     }
 
+    public List<ProjectDetailAPIRes> getLastedProjectByUserId(Long userId, Long id) {
+        User user = getUser(userId);
+
+        validateProjectCardCreator(user, id);
+
+        return projectJpaRepository.findLatestProjectByUserId(id);
+    }
+
     private boolean isExistsNotEndProjectCard(User tokenUser) {
         return !projectJpaRepository.findNotEndProjectOneByCreatorId(tokenUser.getId(),
             PageRequest.of(0, 1)).isEmpty();

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustom.java
@@ -19,4 +19,6 @@ public interface ProjectRepositoryCustom {
     );
 
     List<Region> getDensityRankProjectsByRegion(int limit);
+
+    List<ProjectDetailAPIRes> findLatestProjectByUserId(Long userId);
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
@@ -9,6 +9,7 @@ import io.oeid.mogakgo.domain.project.application.ProjectService;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDensityRankRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailInfoAPIRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectIdRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectInfoAPIRes;
 import io.oeid.mogakgo.domain.project_join_req.presentation.dto.res.ProjectJoinRequestRes;
@@ -93,6 +94,12 @@ public class ProjectController implements ProjectSwagger {
         @UserId Long userId, @PathVariable Long projectId, @PathVariable Long id
         ) {
         return ResponseEntity.ok().body(projectService.getByProjectId(userId, id, projectId));
+    }
+
+    @GetMapping("/{id}/info")
+    public ResponseEntity<ProjectDetailInfoAPIRes> getByUserId(
+        @UserId Long userId, @PathVariable Long id) {
+        return ResponseEntity.ok().body(ProjectDetailInfoAPIRes.of(projectService.getLastedProjectByUserId(userId, id)));
     }
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDetailInfoAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDetailInfoAPIRes.java
@@ -1,0 +1,19 @@
+package io.oeid.mogakgo.domain.project.presentation.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "사용자가 생성한 최근 프로젝트 조회 응답 DTO")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProjectDetailInfoAPIRes {
+
+    private final List<ProjectDetailAPIRes> response;
+
+    public static ProjectDetailInfoAPIRes of(List<ProjectDetailAPIRes> response) {
+        return new ProjectDetailInfoAPIRes(response);
+    }
+}


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자가 생성한 최신 프로젝트 상세 조회 API 개발

### 이슈 번호
- close #245 

## 특이 사항 🫶 
- 사용자의 `userId` 를 통해 해당 사용자가 현재 생성한 프로젝트를 조회하도록 구현하는 과정에서, 해당 사용자가 프로젝트를 생성하지 않아서 조회가 안되는 경우에 대해 빈 데이터를 전달하도록 했습니다! 해당 API는 1개 이상의 프로젝트를 조회하는 경우는 존재하지 않지만 빈 값만 전달해주는 것보다 데이터를 한 번 묶어서 전달하는 게 좋을 것 같아 아래 응답 형식으로 반환하도록 구현했습니다! 이 부분 관련해서 더 좋은 생각이 있는지 피드백 부탁드립니다~!
```json
{
   "response": []
}
```