### PR TITLE
[REFACT] 사용자의 프로젝트 조회 API 리팩토링

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/application/ProjectService.java
@@ -22,6 +22,7 @@ import io.oeid.mogakgo.domain.project.infrastructure.ProjectJpaRepository;
 import io.oeid.mogakgo.domain.project.presentation.dto.req.ProjectCreateReq;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDensityRankRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailInfoAPIRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectInfoAPIRes;
 import io.oeid.mogakgo.domain.project_join_req.exception.ProjectJoinRequestException;
 import io.oeid.mogakgo.domain.project_join_req.infrastructure.ProjectJoinRequestJpaRepository;
@@ -179,7 +180,7 @@ public class ProjectService {
         return new ProjectDensityRankRes(regionRankList);
     }
 
-    public List<ProjectDetailAPIRes> getLastedProjectByUserId(Long userId, Long id) {
+    public ProjectDetailInfoAPIRes getLastedProjectByUserId(Long userId, Long id) {
         User user = getUser(userId);
 
         validateProjectCardCreator(user, id);

--- a/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/infrastructure/ProjectRepositoryCustom.java
@@ -5,6 +5,7 @@ import io.oeid.mogakgo.common.base.CursorPaginationResult;
 import io.oeid.mogakgo.domain.geo.domain.enums.Region;
 import io.oeid.mogakgo.domain.project.domain.entity.enums.ProjectStatus;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailAPIRes;
+import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectDetailInfoAPIRes;
 import io.oeid.mogakgo.domain.project.presentation.dto.res.ProjectInfoAPIRes;
 import java.util.List;
 
@@ -20,5 +21,5 @@ public interface ProjectRepositoryCustom {
 
     List<Region> getDensityRankProjectsByRegion(int limit);
 
-    List<ProjectDetailAPIRes> findLatestProjectByUserId(Long userId);
+    ProjectDetailInfoAPIRes findLatestProjectByUserId(Long userId);
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/ProjectController.java
@@ -99,7 +99,7 @@ public class ProjectController implements ProjectSwagger {
     @GetMapping("/{id}/info")
     public ResponseEntity<ProjectDetailInfoAPIRes> getByUserId(
         @UserId Long userId, @PathVariable Long id) {
-        return ResponseEntity.ok().body(ProjectDetailInfoAPIRes.of(projectService.getLastedProjectByUserId(userId, id)));
+        return ResponseEntity.ok().body(projectService.getLastedProjectByUserId(userId, id));
     }
 
 }

--- a/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDetailInfoAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/project/presentation/dto/res/ProjectDetailInfoAPIRes.java
@@ -11,9 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProjectDetailInfoAPIRes {
 
+    private final Long matchingId;
     private final List<ProjectDetailAPIRes> response;
 
-    public static ProjectDetailInfoAPIRes of(List<ProjectDetailAPIRes> response) {
-        return new ProjectDetailInfoAPIRes(response);
+    public static ProjectDetailInfoAPIRes of(Long matchingId, List<ProjectDetailAPIRes> response) {
+        return new ProjectDetailInfoAPIRes(matchingId, response);
     }
 }


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자의 프로젝트 조회 시, 매칭된 프로젝트도 조회할 수 있도록 수정
- [x] 매칭된 프로젝트의 경우, 매칭 아이디도 같이 전달하도로 수정

### 이슈 번호
- close #252 

## 특이 사항 🫶 