### PR TITLE
Refact/#261 UserGithubUtil 리펙토링

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/user/application/UserService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/application/UserService.java
@@ -21,7 +21,9 @@ import io.oeid.mogakgo.domain.user.util.UserGithubUtil;
 import io.oeid.mogakgo.exception.code.ErrorCode400;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -58,7 +60,8 @@ public class UserService {
     public List<UserDevelopLanguageRes> updateUserDevelopLanguages(long userId) {
         User user = userCommonService.getUserById(userId);
         user.deleteAllDevelopLanguageTags();
-        var languages = userGithubUtil.updateUserDevelopLanguage(user.getRepositoryUrl());
+        var languageMap = userGithubUtil.updateUserDevelopLanguage(user.getRepositoryUrl());
+        var languages = sortDevelopLanguageMap(languageMap);
         languages.forEach((key, value) -> {
             UserDevelopLanguageTag developLanguageTag = UserDevelopLanguageTag.builder()
                 .user(user)
@@ -109,6 +112,14 @@ public class UserService {
         if (wantedJobSet.size() != wantedJobs.size()) {
             throw new UserException(ErrorCode400.USER_WANTED_JOB_DUPLICATE);
         }
+    }
+
+    private Map<String, Integer> sortDevelopLanguageMap(Map<String, Integer> languageMap){
+        List<String> languageKeys = new ArrayList<>(languageMap.keySet());
+        languageKeys.sort((o1, o2) -> languageMap.get(o2).compareTo(languageMap.get(o1)));
+        Map<String, Integer> result = new LinkedHashMap<>();
+        languageKeys.subList(0, 3).forEach(key -> result.put(key, languageMap.get(key)));
+        return result;
     }
 
 }


### PR DESCRIPTION
## 🚀 개발 사항
- 기존 동기처리 방식으로 순차적으로 Github API에서 언어 정보를 호출하던 방식에서 비동기 호출 후 종합 방식으로 리펙토링을 진행했습니다.
- 19개 레포를 갖고 있는 제 ID 기준 3.986 sec -> 1.295 sec (67.5%) 성능 향상을 이뤄냈습니다.
  ![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/85854384/9a2ca200-7fd3-449f-b8bf-a5a9a1062001)


### 이슈 번호

- close #261 

## 특이 사항 🫶 
