### PR TITLE
[REFACT] 클라이언트와의 웹 소켓 연결 후, 클라이언트의 요청을 수신해서 세션을 저장하도록 리팩토링

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementSocketService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementSocketService.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oeid.mogakgo.domain.achievement.domain.entity.AchievementMessage;
 import io.oeid.mogakgo.domain.achievement.exception.AchievementException;
 import io.oeid.mogakgo.domain.achievement.infrastructure.session.AchievementSessionRepository;
+import io.oeid.mogakgo.domain.user.application.UserCommonService;
+import io.oeid.mogakgo.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -20,6 +22,7 @@ import org.springframework.web.socket.WebSocketSession;
 public class AchievementSocketService {
 
     private final ObjectMapper objectMapper;
+    private final UserCommonService userCommonService;
     private final AchievementSessionRepository achievementSessionRepository;
 
     public void addSession(Long userId, WebSocketSession session) {
@@ -47,5 +50,9 @@ public class AchievementSocketService {
                 throw new AchievementException(ACHIEVEMENT_WEB_SOCKET_ERROR);
             }
         }
+    }
+
+    public User validateUser(Long userId) {
+        return userCommonService.getUserById(userId);
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/handler/AchievementSocketHandler.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/handler/AchievementSocketHandler.java
@@ -2,13 +2,14 @@ package io.oeid.mogakgo.domain.achievement.handler;
 
 import static io.oeid.mogakgo.exception.code.ErrorCode500.ACHIEVEMENT_WEB_SOCKET_ERROR;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oeid.mogakgo.domain.achievement.application.AchievementSocketService;
 import io.oeid.mogakgo.domain.achievement.exception.AchievementException;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
@@ -18,19 +19,21 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 @RequiredArgsConstructor
 public class AchievementSocketHandler extends TextWebSocketHandler {
 
+    private final ObjectMapper objectMapper;
     private final AchievementSocketService achievementSocketService;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        Map<String, Object> attributes = session.getAttributes();
-        Long userId = (Long) attributes.get("userId");
-        achievementSocketService.addSession(userId, session);
         log.info("afterConnectionEstablished: {}", session.getId());
     }
 
     @Override
-    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) {
-        throw new UnsupportedOperationException();
+    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+        TextMessage textMessage = (TextMessage) message;
+        String payload = textMessage.getPayload();
+        Long userId = objectMapper.readValue(payload, Long.class);
+        achievementSocketService.validateUser(userId);
+        achievementSocketService.addSession(userId, session);
     }
 
     @Override


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 클라이언트와의 웹 소켓 연결 후, 클라이언트의 요청을 수신해서 세션을 저장하도록 리팩토링

### 이슈 번호
- close #288 

## 특이 사항 🫶 
