### PR TITLE
[REFACT] 소켓 연결 후 세션 처리 로직 리팩토링 및 progressCount NPE 해결

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/event/handler/AchievementEventHandler.java
+++ b/src/main/java/io/oeid/mogakgo/common/event/handler/AchievementEventHandler.java
@@ -160,11 +160,13 @@ public class AchievementEventHandler {
             log.info("call socket for event {} completion", event.getAchievementId());
 
             // 업적 달성 후, 클라이언트에게 socket 통신
+            Achievement achievement = getById(event.getAchievementId());
             achievementSocketService.sendMessageForAchievementCompletion(
                 achievementSessionRepository.getSession(event.getUserId()),
                 AchievementMessage.builder()
                     .userId(event.getUserId())
                     .achievementId(event.getAchievementId())
+                    .progressCount(achievement.getRequirementValue())
                     .completed(Boolean.TRUE)
                     .build()
             );
@@ -200,6 +202,7 @@ public class AchievementEventHandler {
                 AchievementMessage.builder()
                     .userId(event.getUserId())
                     .achievementId(event.getAchievementId())
+                    .progressCount(achievement.getRequirementValue())
                     .completed(Boolean.TRUE)
                     .build()
             );

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementSocketService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementSocketService.java
@@ -44,6 +44,7 @@ public class AchievementSocketService {
                 String jsonMessage = objectMapper.writeValueAsString(message);
                 TextMessage textMessage = new TextMessage(jsonMessage);
                 session.sendMessage(textMessage);
+                log.info("send message to session {} completely", session.getId());
             } catch (JsonProcessingException e) {
                 log.error("failed to convert Json message from object: {}", e.getMessage());
             } catch (Exception e) {
@@ -55,6 +56,8 @@ public class AchievementSocketService {
 
     @Async
     public void sendMessageForAchievementCompletion(WebSocketSession session, AchievementMessage message) {
+
+        log.info("session {} is opened: ", session.getId(), session.isOpen());
 
         if (session != null && session.isOpen()) {
             try {

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/domain/entity/vo/UserId.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/domain/entity/vo/UserId.java
@@ -1,0 +1,18 @@
+package io.oeid.mogakgo.domain.achievement.domain.entity.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserId {
+
+    private final Long userId;
+
+    @Builder
+    @JsonCreator
+    private UserId(Long userId) {
+        this.userId = userId;
+    }
+
+}

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/handler/AchievementSocketHandler.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/handler/AchievementSocketHandler.java
@@ -4,6 +4,7 @@ import static io.oeid.mogakgo.exception.code.ErrorCode500.ACHIEVEMENT_WEB_SOCKET
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.oeid.mogakgo.domain.achievement.application.AchievementSocketService;
+import io.oeid.mogakgo.domain.achievement.domain.entity.vo.UserId;
 import io.oeid.mogakgo.domain.achievement.exception.AchievementException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,9 +32,12 @@ public class AchievementSocketHandler extends TextWebSocketHandler {
     public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
         TextMessage textMessage = (TextMessage) message;
         String payload = textMessage.getPayload();
-        Long userId = objectMapper.readValue(payload, Long.class);
+        UserId id = objectMapper.readValue(payload, UserId.class);
+        Long userId = id.getUserId();
+        log.info("extract userId {} from payload", userId);
         achievementSocketService.validateUser(userId);
         achievementSocketService.addSession(userId, session);
+        log.info("session {} saved completely from userId {}", session.getId(), userId);
     }
 
     @Override


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 소켓 연결 후, 세션을 `userId` 로 key 값을 저장해 세션을 저장하도록 리팩토링
- [x] 업적 달성 시에 소켓을 통해 데이터 전송 시, progressCount에 `null` 이 들어가는 이슈 해결

### 이슈 번호
- close #303 

## 특이 사항 🫶 
