### PR TITLE
[REFACT] 사용자의 대표 업적 변경 API 수정

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/aop/AchievementEventAspect.java
+++ b/src/main/java/io/oeid/mogakgo/common/aop/AchievementEventAspect.java
@@ -3,7 +3,7 @@ package io.oeid.mogakgo.common.aop;
 import static io.oeid.mogakgo.exception.code.ErrorCode404.PROJECT_JOIN_REQUEST_NOT_FOUND;
 
 import io.oeid.mogakgo.domain.achievement.application.AchievementEventService;
-import io.oeid.mogakgo.domain.achievement.application.AchievementFacadeService;
+import io.oeid.mogakgo.domain.achievement.application.AchievementProgressService;
 import io.oeid.mogakgo.domain.achievement.domain.entity.enums.ActivityType;
 import io.oeid.mogakgo.domain.matching.application.MatchingService;
 import io.oeid.mogakgo.domain.profile.presentation.dto.req.UserProfileLikeCreateAPIReq;
@@ -40,7 +40,7 @@ public class AchievementEventAspect {
     private final ProjectJpaRepository projectRepository;
     private final ProjectJoinRequestJpaRepository projectJoinRequestRepository;
     private final MatchingService matchingService;
-    private final AchievementFacadeService achievementFacadeService;
+    private final AchievementProgressService achievementProgressService;
 
     @Pointcut("execution(public * io.oeid.mogakgo.domain.review.application.ReviewService.createNewReview(Long, ..))")
     public void updateJandiRateExecution() {}
@@ -142,7 +142,7 @@ public class AchievementEventAspect {
         Long receiverId = request.getReceiverId();
         achievementEventService.publishAccumulateEventWithVerify(
             receiverId, ActivityType.WHAT_A_POPULAR_PERSON,
-            achievementFacadeService.getAccumulatedProgressCount(receiverId, ActivityType.WHAT_A_POPULAR_PERSON)
+            getAccumulatedProgressCount(receiverId, ActivityType.WHAT_A_POPULAR_PERSON)
         );
     }
 
@@ -162,7 +162,7 @@ public class AchievementEventAspect {
     }
 
     private Integer getAccumulatedProgressCount(Long userId, ActivityType activityType) {
-        return achievementFacadeService.getAccumulatedProgressCount(userId, activityType);
+        return achievementProgressService.getAccumulatedProgressCount(userId, activityType);
     }
 
     private Long getParticipantIdFromJoinRequest(Long projectRequestId) {

--- a/src/main/java/io/oeid/mogakgo/common/event/handler/AchievementEventHandler.java
+++ b/src/main/java/io/oeid/mogakgo/common/event/handler/AchievementEventHandler.java
@@ -42,6 +42,8 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class AchievementEventHandler {
 
+    private static final String SUBSCRIBE_DESTINATIONN = "/topic/achievement/";
+
     private final UserAchievementJpaRepository userAchievementRepository;
     private final AchievementJpaRepository achievementRepository;
     private final UserActivityJpaRepository userActivityRepository;
@@ -71,7 +73,7 @@ public class AchievementEventHandler {
 
                 log.info("call socket for event {} in progress", event.getAchievementId());
 
-                messagingTemplate.convertAndSend("/topic/achievement/" + event.getUserId(),
+                messagingTemplate.convertAndSend(SUBSCRIBE_DESTINATIONN + event.getUserId(),
                     AchievementMessage.builder()
                         .userId(event.getUserId())
                         .achievementId(event.getAchievementId())
@@ -135,7 +137,7 @@ public class AchievementEventHandler {
                 log.info("call socket for event {} completion", event.getAchievementId());
                 notificationService.createAchievementNotification(user.getId(), achievement);
 
-                messagingTemplate.convertAndSend("/topic/achievement/" + event.getUserId(),
+                messagingTemplate.convertAndSend(SUBSCRIBE_DESTINATIONN + event.getUserId(),
                     AchievementMessage.builder()
                         .userId(event.getUserId())
                         .achievementId(event.getAchievementId())
@@ -170,7 +172,7 @@ public class AchievementEventHandler {
             // 업적 달성 후, 클라이언트에게 socket 통신
             Achievement achievement = getById(event.getAchievementId());
 
-            messagingTemplate.convertAndSend("/topic/achievement/" + event.getUserId(),
+            messagingTemplate.convertAndSend(SUBSCRIBE_DESTINATIONN + event.getUserId(),
                 AchievementMessage.builder()
                     .userId(event.getUserId())
                     .achievementId(event.getAchievementId())
@@ -209,7 +211,7 @@ public class AchievementEventHandler {
             notificationService.createAchievementNotification(userAchievement.getUser().getId(), achievement);
 
             // 업적 달성 후, 클라이언트에게 socket 통신
-            messagingTemplate.convertAndSend("/topic/achievement/" + event.getUserId(),
+            messagingTemplate.convertAndSend(SUBSCRIBE_DESTINATIONN + event.getUserId(),
                 AchievementMessage.builder()
                     .userId(event.getUserId())
                     .achievementId(event.getAchievementId())

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementEventService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementEventService.java
@@ -28,12 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AchievementEventService {
 
-    private final AchievementService achievementService;
+    // 작업과 동시에 업적 달성이 가능한, progressCount 최솟값
+    private static final Integer MIN_PROGRESS_COUNT = 1;
+
+    private final AchievementProgressService achievementProgressService;
     private final AchievementFacadeService achievementFacadeService;
     private final ApplicationEventPublisher eventPublisher;
-
-    // 작업과 동시에 업적 달성이 가능한, progressCount 최솟값
-    private final Integer MIN_PROGRESS_COUNT = 1;
 
     // 달성 자격요건의 검증 없이 한 번에 달성 가능한 업적에 대한 이벤트 발행
     @Async("threadPoolTaskExecutor")
@@ -186,7 +186,7 @@ public class AchievementEventService {
             .getAvailableAchievementId(userId, activityType);
 
         // 오늘을 제외한, 업적의 진행도 조회
-        Map<ActivityType, Integer> map = achievementService
+        Map<ActivityType, Integer> map = achievementProgressService
             .getProgressCountMap(userId, List.of(activityType));
 
         if (achievementId != null) {

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementFacadeService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementFacadeService.java
@@ -48,8 +48,4 @@ public class AchievementFacadeService {
     public Long getAvailableAchievementIdWithoutNull(Long userId, ActivityType activityType) {
         return userAchievementRepository.getAvailableAchievementWithoutNull(userId, activityType);
     }
-
-    public Integer getAccumulatedProgressCount(Long userId, ActivityType activityType) {
-        return userAchievementRepository.getAccumulatedProgressCountByActivity(userId, activityType);
-    }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementProgressService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementProgressService.java
@@ -1,0 +1,58 @@
+package io.oeid.mogakgo.domain.achievement.application;
+
+import io.oeid.mogakgo.domain.achievement.domain.entity.UserActivity;
+import io.oeid.mogakgo.domain.achievement.domain.entity.enums.ActivityType;
+import io.oeid.mogakgo.domain.achievement.infrastructure.UserAchievementJpaRepository;
+import io.oeid.mogakgo.domain.achievement.infrastructure.UserActivityJpaRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AchievementProgressService {
+
+    private final UserAchievementJpaRepository userAchievementRepository;
+    private final UserActivityJpaRepository userActivityRepository;
+
+
+    public Integer getAccumulatedProgressCount(Long userId, ActivityType activityType) {
+        return userAchievementRepository.getAccumulatedProgressCountByActivity(userId, activityType);
+    }
+
+    public Map<ActivityType, Integer> getProgressCountMap(Long userId, List<ActivityType> activityList) {
+        return activityList.stream().collect(Collectors.toMap(
+            activityType -> activityType,
+            activityType -> {
+                List<UserActivity> history = userActivityRepository
+                    .findByUserIdAndActivityType(userId, activityType);
+                return !history.isEmpty() ? getSeqProgressCountFromToday(history) : 0;
+            }
+        ));
+    }
+
+    private Integer getSeqProgressCountFromToday(List<UserActivity> activityList) {
+        LocalDate today = LocalDate.now();
+        if (!equalToLocalDate(today, activityList.get(0).getCreatedAt())) {
+            today = today.minusDays(1);
+        }
+        return validateContinuous(today, 0, activityList, 0);
+    }
+
+    private int validateContinuous(LocalDate date, int idx, List<UserActivity> activityList, int count) {
+        if (idx == activityList.size() || !equalToLocalDate(date, activityList.get(idx).getCreatedAt())) {
+            return count;
+        }
+        return validateContinuous(date.minusDays(1), idx + 1, activityList, count + 1);
+    }
+
+    private boolean equalToLocalDate(LocalDate target, LocalDateTime comparison) {
+        return target.equals(comparison.toLocalDate());
+    }
+}

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/dto/res/UserAchievementInfoRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/dto/res/UserAchievementInfoRes.java
@@ -1,11 +1,11 @@
 package io.oeid.mogakgo.domain.achievement.application.dto.res;
 
+import io.oeid.mogakgo.domain.achievement.domain.entity.UserAchievement;
 import io.oeid.mogakgo.domain.achievement.domain.entity.enums.RequirementType;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class UserAchievementInfoRes {
 
     private final Long userId;
@@ -17,4 +17,34 @@ public class UserAchievementInfoRes {
     private final Integer requirementValue;
     private final Integer progressCount;
     private final Boolean completed;
+
+    @Builder
+    private UserAchievementInfoRes(Long userId, Long achievementId, String title, String imgUrl,
+        String description, RequirementType requirementType, Integer requirementValue,
+        Integer progressCount, Boolean completed) {
+        this.userId = userId;
+        this.achievementId = achievementId;
+        this.title = title;
+        this.imgUrl = imgUrl;
+        this.description = description;
+        this.requirementType = requirementType;
+        this.requirementValue = requirementValue;
+        this.progressCount = progressCount;
+        this.completed = completed;
+    }
+
+    public static UserAchievementInfoRes of(UserAchievement userAchievement, Integer progressCount) {
+        return new UserAchievementInfoRes(
+            userAchievement.getUser().getId(),
+            userAchievement.getAchievement().getId(),
+            userAchievement.getAchievement().getTitle(),
+            userAchievement.getAchievement().getImgUrl(),
+            userAchievement.getAchievement().getDescription(),
+            userAchievement.getAchievement().getRequirementType(),
+            userAchievement.getAchievement().getRequirementValue(),
+            progressCount,
+            userAchievement.getCompleted()
+        );
+    }
+
 }

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementRepositoryCustomImpl.java
@@ -110,17 +110,17 @@ public class UserAchievementRepositoryCustomImpl implements UserAchievementRepos
 
         return sql1.stream()
             .sorted(Comparator.comparing(tuple -> tuple.get(1, Long.class))).map(
-                tuple -> new UserAchievementInfoRes(
-                    userId,
-                    tuple.get(1, Long.class),
-                    tuple.get(2, String.class),
-                    tuple.get(3, String.class),
-                    tuple.get(4, String.class),
-                    tuple.get(5, RequirementType.class),
-                    tuple.get(6, Integer.class),
-                    Integer.valueOf(String.valueOf(tuple.get(7, Long.class))),
-                    tuple.get(8, Boolean.class)
-                )
+                tuple -> UserAchievementInfoRes.builder()
+                    .userId(userId)
+                    .achievementId(tuple.get(1, Long.class))
+                    .title(tuple.get(2, String.class))
+                    .imgUrl(tuple.get(3, String.class))
+                    .description(tuple.get(4, String.class))
+                    .requirementType(tuple.get(5, RequirementType.class))
+                    .requirementValue(tuple.get(6, Integer.class))
+                    .progressCount(Integer.valueOf(String.valueOf(tuple.get(7, Long.class))))
+                    .completed(tuple.get(8, Boolean.class))
+                    .build()
             ).toList();
     }
 

--- a/src/main/java/io/oeid/mogakgo/domain/user/application/UserAchievementService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/application/UserAchievementService.java
@@ -4,7 +4,12 @@ import static io.oeid.mogakgo.exception.code.ErrorCode400.NON_ACHIEVED_USER_ACHI
 import static io.oeid.mogakgo.exception.code.ErrorCode403.USER_FORBIDDEN_OPERATION;
 import static io.oeid.mogakgo.exception.code.ErrorCode404.ACHIEVEMENT_NOT_FOUND;
 
+import io.oeid.mogakgo.domain.achievement.application.AchievementProgressService;
+import io.oeid.mogakgo.domain.achievement.application.dto.res.UserAchievementInfoRes;
+import io.oeid.mogakgo.domain.achievement.domain.entity.Achievement;
 import io.oeid.mogakgo.domain.achievement.domain.entity.UserAchievement;
+import io.oeid.mogakgo.domain.achievement.domain.entity.enums.ActivityType;
+import io.oeid.mogakgo.domain.achievement.domain.entity.enums.RequirementType;
 import io.oeid.mogakgo.domain.achievement.exception.AchievementException;
 import io.oeid.mogakgo.domain.achievement.exception.UserAchievementException;
 import io.oeid.mogakgo.domain.achievement.infrastructure.AchievementJpaRepository;
@@ -12,6 +17,7 @@ import io.oeid.mogakgo.domain.achievement.infrastructure.UserAchievementJpaRepos
 import io.oeid.mogakgo.domain.user.domain.User;
 import io.oeid.mogakgo.domain.user.exception.UserException;
 import io.oeid.mogakgo.domain.user.presentation.dto.req.UserAchievementUpdateApiRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,9 +31,10 @@ public class UserAchievementService {
     private final UserCommonService userCommonService;
     private final AchievementJpaRepository achievementRepository;
     private final UserAchievementJpaRepository userAchievementRepository;
+    private final AchievementProgressService achievementProgressService;
 
     @Transactional
-    public Long updateAchievement(Long userId, UserAchievementUpdateApiRequest request) {
+    public UserAchievementInfoRes updateAchievement(Long userId, UserAchievementUpdateApiRequest request) {
         User user = userCommonService.getUserById(userId);
         // 토큰 값과 업데이트하려는 사용자 ID의 일치 여부 검증
         validateUserId(user, userId);
@@ -37,9 +44,34 @@ public class UserAchievementService {
             .findByUserAndAchievementId(userId, request.getAchievementId())
             .orElseThrow(() -> new UserAchievementException(NON_ACHIEVED_USER_ACHIEVEMENT));
         // 변경하려는 업적의 달성 여부 검증
-        userAchievement.validateAvailableUpdateAchievement();
+        validateAvailableUpdateAchievement(userAchievement);
         user.updateAchievement(userAchievement.getAchievement());
-        return user.getId();
+        return UserAchievementInfoRes.of(
+            userAchievement,
+            getProgressCountForAchievement(userId, userAchievement.getAchievement())
+        );
+    }
+
+    private void validateAvailableUpdateAchievement(UserAchievement userAchievement) {
+        if (userAchievement.getCompleted().equals(Boolean.FALSE) &&
+            isAlreadyAchievedAchievement(
+                userAchievement.getAchievement().getId(),
+                userAchievement.getAchievement().getActivityType())) {
+            throw new UserAchievementException(NON_ACHIEVED_USER_ACHIEVEMENT);
+        }
+    }
+
+    private boolean isAlreadyAchievedAchievement(Long achievementId, ActivityType activityType) {
+        return !achievementId.equals(userAchievementRepository
+            .findMinAchievementIdByActivityType(activityType));
+    }
+
+    private Integer getProgressCountForAchievement(Long userId, Achievement achievement) {
+        if (achievement.getRequirementType().equals(RequirementType.ACCUMULATE)) {
+            return achievementProgressService.getAccumulatedProgressCount(userId, achievement.getActivityType());
+        }
+        return achievementProgressService.getProgressCountMap(userId,
+            List.of(achievement.getActivityType())).get(achievement.getActivityType());
     }
 
     public void validateUserId(User user, Long userId) {

--- a/src/main/java/io/oeid/mogakgo/domain/user/presentation/UserController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/presentation/UserController.java
@@ -2,6 +2,7 @@ package io.oeid.mogakgo.domain.user.presentation;
 
 import io.oeid.mogakgo.common.annotation.UserId;
 import io.oeid.mogakgo.common.swagger.template.UserSwagger;
+import io.oeid.mogakgo.domain.achievement.application.dto.res.UserAchievementInfoRes;
 import io.oeid.mogakgo.domain.matching.application.UserMatchingService;
 import io.oeid.mogakgo.domain.user.application.UserAchievementService;
 import io.oeid.mogakgo.domain.user.application.UserService;
@@ -86,7 +87,7 @@ public class UserController implements UserSwagger {
     public ResponseEntity<UserAchievementUpdateApiResponse> updateUserMainAchievement(
         @UserId Long userId, @Valid @RequestBody UserAchievementUpdateApiRequest request
     ) {
-        Long id = userAchievementService.updateAchievement(userId, request);
-        return ResponseEntity.ok().body(UserAchievementUpdateApiResponse.from(id));
+        UserAchievementInfoRes response = userAchievementService.updateAchievement(userId, request);
+        return ResponseEntity.ok().body(UserAchievementUpdateApiResponse.from(response));
     }
 }

--- a/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserAchievementUpdateApiResponse.java
+++ b/src/main/java/io/oeid/mogakgo/domain/user/presentation/dto/res/UserAchievementUpdateApiResponse.java
@@ -1,5 +1,7 @@
 package io.oeid.mogakgo.domain.user.presentation.dto.res;
 
+import io.oeid.mogakgo.domain.achievement.application.dto.res.UserAchievementInfoRes;
+import io.oeid.mogakgo.domain.achievement.domain.entity.enums.RequirementType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -15,7 +17,41 @@ public class UserAchievementUpdateApiResponse {
     @NotNull
     private final Long userId;
 
-    public static UserAchievementUpdateApiResponse from(Long userId) {
-        return new UserAchievementUpdateApiResponse(userId);
+    @Schema(description = "대표 업적 ID")
+    private final Long achievementId;
+
+    @Schema(description = "대표 업적 타이틀")
+    private final String title;
+
+    @Schema(description = "대표 업적 이미지 Url")
+    private final String imgUrl;
+
+    @Schema(description = "대표 업적 설명")
+    private final String description;
+
+    @Schema(description = "대표 업적 달성 타입")
+    private final RequirementType requirementType;
+
+    @Schema(description = "대표 업적 달성 조건")
+    private final Integer requirementValue;
+
+    @Schema(description = "대표 업적 진행 횟수")
+    private final Integer progressCount;
+
+    @Schema(description = "대표 업적 달성 여부")
+    private final Boolean completed;
+
+    public static UserAchievementUpdateApiResponse from(UserAchievementInfoRes response) {
+        return new UserAchievementUpdateApiResponse(
+            response.getUserId(),
+            response.getAchievementId(),
+            response.getTitle(),
+            response.getImgUrl(),
+            response.getDescription(),
+            response.getRequirementType(),
+            response.getRequirementValue(),
+            response.getProgressCount(),
+            response.getCompleted()
+        );
     }
 }


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자의 대표 업적 변경 API 응답 타입 수정
- [x] 점진적 업적에 대한 대표 업적 변경 검증 로직 수정
- [x] 업적 타입별 `progressCount` 에 대한 클래스 분리 

### 이슈 번호
- close #331 

## 특이 사항 🫶 
