### PR TITLE
[BUG] 조회한 프로필 카드에 대한 정렬 로직 오류 수정

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -43,7 +43,7 @@ public class ProfileCardService {
             .findByConditionWithPagination(userId, region, pageable);
 
         if (profiles.getData().size() >= 2) {
-            Collections.shuffle(profiles.getData().subList(0, profiles.getData().size() - 1));
+            Collections.shuffle(profiles.getData().subList(1, profiles.getData().size()));
         }
         return profiles;
     }
@@ -54,7 +54,7 @@ public class ProfileCardService {
         var result = profileCardRepository.findByConditionWithPaginationPublic(region,
             pageable.getCursorId(), pageable.getPageSize());
         if (result.size() >= 2) {
-            Collections.shuffle(result.subList(0, result.size() - 1));
+            Collections.shuffle(result.subList(1, result.size()));
         }
         var profiles = result.stream().map(
             profileCard -> new UserProfileInfoAPIRes(


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 선택한 구역의 프로필 카드 리스트 조회 API에서 랜덤 정렬에 대한 오류 수정

### 이슈 번호
- close #344 

## 특이 사항 🫶 
