### PR TITLE
[BUG] 선택한 구역에 대한 프로필 리스트 조회에서 페이지네이션이 제대로 작동하지 않아요!

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -43,7 +43,7 @@ public class ProfileCardService {
             .findByConditionWithPagination(userId, region, pageable);
 
         if (profiles.getData().size() >= 2) {
-            Collections.shuffle(profiles.getData().subList(0, profiles.getData().size() - 1));
+            Collections.shuffle(profiles.getData().subList(1, profiles.getData().size()));
         }
         return profiles;
     }
@@ -54,7 +54,7 @@ public class ProfileCardService {
         var result = profileCardRepository.findByConditionWithPaginationPublic(region,
             pageable.getCursorId(), pageable.getPageSize());
         if (result.size() >= 2) {
-            Collections.shuffle(result.subList(0, result.size() - 1));
+            Collections.shuffle(result.subList(1, result.size()));
         }
         var profiles = result.stream().map(
             profileCard -> new UserProfileInfoAPIRes(

--- a/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/application/ProfileCardService.java
@@ -43,7 +43,7 @@ public class ProfileCardService {
             .findByConditionWithPagination(userId, region, pageable);
 
         if (profiles.getData().size() >= 2) {
-            Collections.shuffle(profiles.getData().subList(1, profiles.getData().size()));
+            Collections.shuffle(profiles.getData().subList(0, profiles.getData().size() - 1));
         }
         return profiles;
     }
@@ -54,7 +54,7 @@ public class ProfileCardService {
         var result = profileCardRepository.findByConditionWithPaginationPublic(region,
             pageable.getCursorId(), pageable.getPageSize());
         if (result.size() >= 2) {
-            Collections.shuffle(result.subList(1, result.size()));
+            Collections.shuffle(result.subList(0, result.size() - 1));
         }
         var profiles = result.stream().map(
             profileCard -> new UserProfileInfoAPIRes(

--- a/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
@@ -30,6 +30,7 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
     ) {
 
         List<ProfileCard> entities = jpaQueryFactory.selectFrom(profileCard)
+            .distinct()
             .innerJoin(profileCard.user, user)
             .on(profileCard.user.id.eq(user.id))
             .where(
@@ -39,7 +40,7 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
                 deletedProfileCardEq()
             )
             // 최근순
-            .orderBy(profileCard.id.desc())
+            .orderBy(user.id.desc())
             .limit(pageable.getPageSize() + 1L)
             .fetch();
 
@@ -78,7 +79,7 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
     }
 
     private BooleanExpression cursorIdCondition(Long cursorId) {
-        return cursorId != null ? profileCard.id.lt(cursorId) : null;
+        return cursorId != null ? user.id.lt(cursorId) : null;
     }
 
     private BooleanExpression excludeUserId(Long userId) {


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 프로필 카드에 대한 커서 기반 페이지네이션의 `cursorId` 기준을 `userId` 로 변경

### 이슈 번호
- close #344 

## 특이 사항 🫶 
