### PR TITLE
[BUG] 업적 달성 관련 오류 수정, 비회원 프로필 리스트 페이지네이션 오류 수정

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/profile/infrastructure/ProfileCardRepositoryCustomImpl.java
@@ -58,10 +58,16 @@ public class ProfileCardRepositoryCustomImpl implements ProfileCardRepositoryCus
 
     public List<ProfileCard> findByConditionWithPaginationPublic(@NonNull Region region,
         Long cursorId, @NonNull Integer pageSize) {
-        return jpaQueryFactory.selectFrom(profileCard).innerJoin(profileCard.user, user)
+        return jpaQueryFactory.selectFrom(profileCard)
+            .innerJoin(profileCard.user, user)
             .on(profileCard.user.id.eq(user.id))
-            .where(cursorIdCondition(cursorId), regionEq(region), deletedProfileCardEq())
-            .orderBy(profileCard.id.desc()).limit(pageSize + 1L).fetch();
+            .where(
+                cursorIdCondition(cursorId),
+                regionEq(region),
+                deletedProfileCardEq()
+            )
+            .orderBy(user.id.desc())
+            .limit(pageSize + 1L).fetch();
     }
 
     private Boolean validateProfileCardLikeBySenderId(Long receiverId, Long userId) {


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 비회원 프로필 리스트 조회 API에서 페이지네이션 오류 수정
- [x] 업적 달성조건 검증 로직에서 오류 수정 

### 이슈 번호
- close #348 

## 특이 사항 🫶 
