### PR TITLE
[REFACT] 사용자의 업적 상세 조회 시, 업적의 progressLevel 필드도 같이 전달하도록 추가

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementService.java
@@ -80,6 +80,7 @@ public class AchievementService {
                 .title(achievement.getTitle())
                 .imgUrl(achievement.getImgUrl())
                 .description(achievement.getDescription())
+                .progressLevel(achievement.getProgressLevel())
                 .requirementType(achievement.getRequirementType())
                 .requirementValue(achievement.getRequirementValue())
                 .progressCount(map.get(achievement.getActivityType()))

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/dto/res/UserAchievementInfoRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/dto/res/UserAchievementInfoRes.java
@@ -13,6 +13,7 @@ public class UserAchievementInfoRes {
     private final String title;
     private final String imgUrl;
     private final String description;
+    private final Integer progressLevel;
     private final RequirementType requirementType;
     private final Integer requirementValue;
     private final Integer progressCount;
@@ -20,13 +21,14 @@ public class UserAchievementInfoRes {
 
     @Builder
     private UserAchievementInfoRes(Long userId, Long achievementId, String title, String imgUrl,
-        String description, RequirementType requirementType, Integer requirementValue,
-        Integer progressCount, Boolean completed) {
+        String description, Integer progressLevel, RequirementType requirementType,
+        Integer requirementValue, Integer progressCount, Boolean completed) {
         this.userId = userId;
         this.achievementId = achievementId;
         this.title = title;
         this.imgUrl = imgUrl;
         this.description = description;
+        this.progressLevel = progressLevel;
         this.requirementType = requirementType;
         this.requirementValue = requirementValue;
         this.progressCount = progressCount;
@@ -40,6 +42,7 @@ public class UserAchievementInfoRes {
             userAchievement.getAchievement().getTitle(),
             userAchievement.getAchievement().getImgUrl(),
             userAchievement.getAchievement().getDescription(),
+            userAchievement.getAchievement().getProgressLevel(),
             userAchievement.getAchievement().getRequirementType(),
             userAchievement.getAchievement().getRequirementValue(),
             progressCount,

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementRepositoryCustomImpl.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementRepositoryCustomImpl.java
@@ -41,6 +41,7 @@ public class UserAchievementRepositoryCustomImpl implements UserAchievementRepos
                 achievement.title,
                 achievement.imgUrl,
                 achievement.description,
+                achievement.progressLevel,
                 achievement.requirementType,
                 achievement.requirementValue,
                 Expressions.numberPath(Long.class, String.valueOf(0)),
@@ -66,6 +67,7 @@ public class UserAchievementRepositoryCustomImpl implements UserAchievementRepos
                 userAchievement.achievement.title,
                 userAchievement.achievement.imgUrl,
                 userAchievement.achievement.description,
+                userAchievement.achievement.progressLevel,
                 userAchievement.achievement.requirementType,
                 userAchievement.achievement.requirementValue,
                 Expressions.numberPath(Long.class, String.valueOf(userActivity.createdAt.count())),
@@ -94,6 +96,7 @@ public class UserAchievementRepositoryCustomImpl implements UserAchievementRepos
                 userAchievement.achievement.title,
                 userAchievement.achievement.imgUrl,
                 userAchievement.achievement.description,
+                userAchievement.achievement.progressLevel,
                 userAchievement.achievement.requirementType,
                 userAchievement.achievement.requirementValue,
                 userAchievement.completed
@@ -116,10 +119,11 @@ public class UserAchievementRepositoryCustomImpl implements UserAchievementRepos
                     .title(tuple.get(2, String.class))
                     .imgUrl(tuple.get(3, String.class))
                     .description(tuple.get(4, String.class))
-                    .requirementType(tuple.get(5, RequirementType.class))
-                    .requirementValue(tuple.get(6, Integer.class))
-                    .progressCount(Integer.valueOf(String.valueOf(tuple.get(7, Long.class))))
-                    .completed(tuple.get(8, Boolean.class))
+                    .progressLevel(tuple.get(5, Integer.class))
+                    .requirementType(tuple.get(6, RequirementType.class))
+                    .requirementValue(tuple.get(7, Integer.class))
+                    .progressCount(Integer.valueOf(String.valueOf(tuple.get(8, Long.class))))
+                    .completed(tuple.get(9, Boolean.class))
                     .build()
             ).toList();
     }

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/dto/res/AchievementInfoAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/dto/res/AchievementInfoAPIRes.java
@@ -24,6 +24,9 @@ public class AchievementInfoAPIRes {
     @Schema(description = "조회할 업적 상세 설명")
     private final String description;
 
+    @Schema(description = "조회할 업적 단계")
+    private final Integer progressLevel;
+
     @Schema(description = "조회할 업적 타입")
     private final RequirementType requirementType;
 
@@ -36,6 +39,7 @@ public class AchievementInfoAPIRes {
             achievement.getTitle(),
             achievement.getImgUrl(),
             achievement.getDescription(),
+            achievement.getProgressLevel(),
             achievement.getRequirementType(),
             achievement.getRequirementValue()
         );

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/dto/res/UserAchievementDetailAPIRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/dto/res/UserAchievementDetailAPIRes.java
@@ -27,6 +27,9 @@ public class UserAchievementDetailAPIRes {
     @Schema(description = "조회할 업적 상세 설명")
     private final String description;
 
+    @Schema(description = "조회할 업적 단계")
+    private final Integer progressLevel;
+
     @Schema(description = "조회할 업적 타입")
     private final RequirementType requirementType;
 
@@ -46,6 +49,7 @@ public class UserAchievementDetailAPIRes {
             response.getTitle(),
             response.getImgUrl(),
             response.getDescription(),
+            response.getProgressLevel(),
             response.getRequirementType(),
             response.getRequirementValue(),
             response.getProgressCount(),


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 사용자의 업적 상세 조회 API의 응답 타입에 `progressLevel` 추가

### 이슈 번호
- close #354 

## 특이 사항 🫶 
