### PR TITLE
Refact/#365 user id annotation

### DIFF
--- a/src/main/java/io/oeid/mogakgo/common/annotation/UserId.java
+++ b/src/main/java/io/oeid/mogakgo/common/annotation/UserId.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Deprecated(forRemoval = true)
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface UserId {

--- a/src/main/java/io/oeid/mogakgo/common/resolver/UserIdAnnotationResolver.java
+++ b/src/main/java/io/oeid/mogakgo/common/resolver/UserIdAnnotationResolver.java
@@ -11,6 +11,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Deprecated(forRemoval = true)
 public class UserIdAnnotationResolver implements HandlerMethodArgumentResolver {
 
     @Override

--- a/src/main/java/io/oeid/mogakgo/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/oeid/mogakgo/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,8 +37,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-        FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain) throws ServletException, IOException {
 
         String accessToken =
             request.getHeader(header) != null ? URLDecoder.decode(request.getHeader(header),
@@ -53,9 +54,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 List<GrantedAuthority> authorities = getAuthorities(
                     claims.get(JwtHelper.ROLES_STR).asArray(String.class));
                 var authentication = new JwtAuthenticationToken(
-                    JwtToken.of(userId, accessToken), "", authorities);
+                    userId, "", authorities);
                 authentication.setDetails(
                     new WebAuthenticationDetailsSource().buildDetails(request));
+                // TODO: SHOULD REMOVE
                 request.setAttribute(JwtHelper.USER_ID_STR, userId);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception e) {

--- a/src/test/java/io/oeid/mogakgo/domain/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/io/oeid/mogakgo/domain/auth/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,94 @@
+package io.oeid.mogakgo.domain.auth.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import io.oeid.mogakgo.core.properties.JwtProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("필터 테스트: JwtAuthenticationFilter")
+class JwtAuthenticationFilterTest {
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @Mock
+    private JwtProperties jwtProperties;
+    @Mock
+    private JwtHelper jwtHelper;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private FilterChain filterChain;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 토큰_인증_성공() throws Exception {
+        // Arrange
+        var expectedUserId = 1L;
+        var expectedRoles = new String[]{"ROLE_USER"};
+
+        Map<String, Claim> claims = Map.of(
+            JwtHelper.USER_ID_STR, mock(Claim.class),
+            JwtHelper.ROLES_STR, mock(Claim.class)
+        );
+        when(request.getHeader(any())).thenReturn("Bearer validToken");
+        when(jwtHelper.verify(anyString())).thenReturn(claims);
+        when(claims.get(JwtHelper.USER_ID_STR).asLong()).thenReturn(expectedUserId);
+        when(claims.get(JwtHelper.ROLES_STR).asArray(String.class)).thenReturn(expectedRoles);
+        // Act
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+        // Assert
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+            .hasFieldOrPropertyWithValue("userId", expectedUserId);
+    }
+
+    @Test
+    void 토큰_인증_실패_잘못된_토큰() throws Exception {
+        // Arrange
+        when(request.getHeader(any())).thenReturn("Bearer invalidToken");
+        when(jwtHelper.verify(anyString())).thenThrow(JWTVerificationException.class);
+        // Act
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+        // Assert
+        verify(filterChain).doFilter(request, response);
+        System.out.println(SecurityContextHolder.getContext().getAuthentication());
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void 토큰_인증_실패_해더에_존재하지_않을_때() throws Exception {
+        // Arrange
+        when(request.getHeader(any())).thenReturn(null);
+        // Act
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+        // Assert
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+}

--- a/src/test/java/io/oeid/mogakgo/domain/auth/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/io/oeid/mogakgo/domain/auth/jwt/JwtAuthenticationFilterTest.java
@@ -64,8 +64,8 @@ class JwtAuthenticationFilterTest {
         // Assert
         verify(filterChain).doFilter(request, response);
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
-        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal())
-            .hasFieldOrPropertyWithValue("userId", expectedUserId);
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(
+            expectedUserId);
     }
 
     @Test


### PR DESCRIPTION
## 🚀 개발 사항
- 불필요한 `@UserId` 어노테이션이 Deprecated 되었습니다.
  - 이에 따른 `UserIdAnnotationResolver`도 Deprecated 되었습니다.
- `JwtAuthenticationFilter`에서 Authentication의 Principal에 UserId를 전달하도록 변경했습니다.
- `JwtAuthenticationFilter` 테스트가 추가되었습니다.

### 이슈 번호
- close #365 

## 특이 사항 🫶 
- 추후 `@UserId`를 삭제할 때 `JwtAuthenticationFilter`의 `request.setAttribute(JwtHelper.USER_ID_STR, userId);` 구문 삭제가 필요합니다.