### PR TITLE
[REFACT] 업적 상세 조회 API에 대해 인덱스 적용 및 쿼리 최적화 리팩토링

### DIFF
--- a/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementService.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/application/AchievementService.java
@@ -3,13 +3,13 @@ package io.oeid.mogakgo.domain.achievement.application;
 import static io.oeid.mogakgo.exception.code.ErrorCode403.ACHIEVEMENT_FORBIDDEN_OPERATION;
 import static io.oeid.mogakgo.exception.code.ErrorCode404.ACHIEVEMENT_NOT_FOUND;
 
-import io.oeid.mogakgo.domain.achievement.application.dto.res.UserAchievementInfoRes;
 import io.oeid.mogakgo.domain.achievement.domain.entity.Achievement;
 import io.oeid.mogakgo.domain.achievement.domain.entity.enums.ActivityType;
 import io.oeid.mogakgo.domain.achievement.domain.entity.enums.RequirementType;
 import io.oeid.mogakgo.domain.achievement.exception.AchievementException;
 import io.oeid.mogakgo.domain.achievement.infrastructure.AchievementJpaRepository;
 import io.oeid.mogakgo.domain.achievement.infrastructure.UserAchievementJpaRepository;
+import io.oeid.mogakgo.domain.achievement.presentation.dto.res.UserAchievementDetailInfoRes;
 import io.oeid.mogakgo.domain.user.application.UserCommonService;
 import io.oeid.mogakgo.domain.user.domain.User;
 import java.util.Collections;
@@ -37,26 +37,26 @@ public class AchievementService {
             .orElseThrow(() -> new AchievementException(ACHIEVEMENT_NOT_FOUND));
     }
 
-    public List<UserAchievementInfoRes> getUserAchievementInfo(Long userId, Long id) {
+    public List<UserAchievementDetailInfoRes> getUserAchievementInfo(Long userId, Long id) {
         User user = validateToken(userId);
         validateUser(user, id);
 
         // 사용자의 미달성, Accumulate 타입 업적에 대한 상세 조회
-        List<UserAchievementInfoRes> result = getNonAchievedAndAccumulateAchiementInfo(userId);
+        List<UserAchievementDetailInfoRes> result = getNonAchievedAndAccumulateAchiementInfo(userId);
 
         // 사용자의 Sequence 타입 업적에 대한 상세 조회
-        List<UserAchievementInfoRes> seqResult = getSequenceAchievementInfoAboutUser(userId);
+        List<UserAchievementDetailInfoRes> seqResult = getSequenceAchievementInfoAboutUser(userId);
 
         return Stream
             .concat(result.stream(), seqResult.stream())
-            .sorted(Comparator.comparing(UserAchievementInfoRes::getAchievementId)).toList();
+            .sorted(Comparator.comparing(UserAchievementDetailInfoRes::getAchievementId)).toList();
     }
 
-    private List<UserAchievementInfoRes> getNonAchievedAndAccumulateAchiementInfo(Long userId) {
+    private List<UserAchievementDetailInfoRes> getNonAchievedAndAccumulateAchiementInfo(Long userId) {
         return userAchievementRepository.getAchievementInfoAboutUser(userId);
     }
 
-    private List<UserAchievementInfoRes> getSequenceAchievementInfoAboutUser(Long userId) {
+    private List<UserAchievementDetailInfoRes> getSequenceAchievementInfoAboutUser(Long userId) {
 
         // 사용자가 진행중이거나 달성중인, Sequence 타입 업적
         List<ActivityType> sequenceList = achievementRepository
@@ -74,9 +74,9 @@ public class AchievementService {
 
         return achievementIds.stream().map(achievementId -> {
             Achievement achievement = achievementFacadeService.getById(achievementId);
-            return UserAchievementInfoRes.builder()
-                .userId(userId)
+            return UserAchievementDetailInfoRes.builder()
                 .achievementId(achievementId)
+                .userId(userId)
                 .title(achievement.getTitle())
                 .imgUrl(achievement.getImgUrl())
                 .description(achievement.getDescription())

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementRepositoryCustom.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/infrastructure/UserAchievementRepositoryCustom.java
@@ -1,12 +1,12 @@
 package io.oeid.mogakgo.domain.achievement.infrastructure;
 
-import io.oeid.mogakgo.domain.achievement.application.dto.res.UserAchievementInfoRes;
 import io.oeid.mogakgo.domain.achievement.domain.entity.enums.ActivityType;
+import io.oeid.mogakgo.domain.achievement.presentation.dto.res.UserAchievementDetailInfoRes;
 import java.util.List;
 
 public interface UserAchievementRepositoryCustom {
 
-    List<UserAchievementInfoRes> getAchievementInfoAboutUser(Long userId);
+    List<UserAchievementDetailInfoRes> getAchievementInfoAboutUser(Long userId);
     Long getAvailableAchievementWithNull(Long userId, ActivityType activityType);
     Long findMinAchievementIdByActivityType(ActivityType activityType);
     Long getAvailableAchievementWithoutNull(Long userId, ActivityType activityType);

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/AchievementController.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/AchievementController.java
@@ -3,9 +3,9 @@ package io.oeid.mogakgo.domain.achievement.presentation;
 import io.oeid.mogakgo.common.annotation.UserId;
 import io.oeid.mogakgo.common.swagger.template.AchievementSwagger;
 import io.oeid.mogakgo.domain.achievement.application.AchievementService;
-import io.oeid.mogakgo.domain.achievement.application.dto.res.UserAchievementInfoRes;
 import io.oeid.mogakgo.domain.achievement.presentation.dto.res.AchievementInfoAPIRes;
 import io.oeid.mogakgo.domain.achievement.presentation.dto.res.UserAchievementDetailAPIRes;
+import io.oeid.mogakgo.domain.achievement.presentation.dto.res.UserAchievementDetailInfoRes;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +25,7 @@ public class AchievementController implements AchievementSwagger {
     public ResponseEntity<List<UserAchievementDetailAPIRes>> getUserAchievementDetail(
         @UserId Long userId, @PathVariable Long id
     ) {
-        List<UserAchievementInfoRes> userAchievementLists = achievementService
+        List<UserAchievementDetailInfoRes> userAchievementLists = achievementService
             .getUserAchievementInfo(userId, id);
 
         return ResponseEntity.ok().body(

--- a/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/dto/res/UserAchievementDetailInfoRes.java
+++ b/src/main/java/io/oeid/mogakgo/domain/achievement/presentation/dto/res/UserAchievementDetailInfoRes.java
@@ -2,20 +2,18 @@ package io.oeid.mogakgo.domain.achievement.presentation.dto.res;
 
 import io.oeid.mogakgo.domain.achievement.domain.entity.enums.RequirementType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Schema(description = "사용자에 대한 업적 상세 정보 조회 응답 DTO")
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserAchievementDetailAPIRes {
-
-    @Schema(description = "업적을 조회할 사용자 ID", example = "11", implementation = Long.class)
-    private final Long userId;
+public class UserAchievementDetailInfoRes {
 
     @Schema(description = "조회할 업적 ID")
     private final Long achievementId;
+
+    @Schema(description = "업적을 조회할 사용자 ID", example = "11", implementation = Long.class)
+    private final Long userId;
 
     @Schema(description = "조회할 업적 타이틀")
     private final String title;
@@ -41,18 +39,19 @@ public class UserAchievementDetailAPIRes {
     @Schema(description = "해당 업적의 달성 여부")
     private final Boolean completed;
 
-    public static UserAchievementDetailAPIRes from(UserAchievementDetailInfoRes response) {
-        return new UserAchievementDetailAPIRes(
-            response.getUserId(),
-            response.getAchievementId(),
-            response.getTitle(),
-            response.getImgUrl(),
-            response.getDescription(),
-            response.getProgressLevel(),
-            response.getRequirementType(),
-            response.getRequirementValue(),
-            response.getProgressCount(),
-            response.getCompleted()
-        );
+    @Builder
+    private UserAchievementDetailInfoRes(Long achievementId, Long userId, String title,
+        String imgUrl, String description, Integer progressLevel, RequirementType requirementType,
+        Integer requirementValue, Integer progressCount, Boolean completed) {
+        this.achievementId = achievementId;
+        this.userId = userId;
+        this.title = title;
+        this.imgUrl = imgUrl;
+        this.description = description;
+        this.progressLevel = progressLevel;
+        this.requirementType = requirementType;
+        this.requirementValue = requirementValue;
+        this.progressCount = progressCount;
+        this.completed = completed;
     }
 }


### PR DESCRIPTION
## 🚀 개발 사항
- [x] 업적 상세 조회 API에 대한 인덱스 적용 및 쿼리 최적화 수행

### 이슈 번호
- close #363 

## 특이 사항 🫶 
<최적화 이전 코드>
```sql
EXPLAIN
SELECT
    uac2.user_id, 
    ac2.id, ac2.title, ac2.progress_level, ac2.requirement_type, ac2.requirement_value, 
    count(uact.created_at) AS processCount, 
    uac2.completed
FROM achievement_tb AS ac2
    INNER JOIN user_achievement_tb AS uac2 ON ac2.id = uac2.achievement_id AN D uac2.user_id = 11
    INNER JOIN user_activity_tb AS uact ON uact.activity_type = ac2.activity_type
WHERE ac2.id IN (
    SELECT max(ac3.id)
    FROM user_activity_tb AS uact2
        INNER JOIN achievement_tb AS ac3 ON ac3.activity_type = uact2.activity_type AND uact2.user_id = 11
        INNER JOIN user_achievement_tb AS uac3 ON uac3.achievement_id = ac3.id
    GROUP BY uact2.activity_type)
ORDER BY ac2.id;
```
![before_optimization](https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/b2bbac9e-416d-4082-8ea7-3cf37ffaebd1)
<img width="702" alt="image" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/590ea54a-fd87-45d5-9d07-82c1fae89db2">

```sql
EXPLAIN
SELECT
   23 AS user_id,
   ac.id, ac.title, ac.img_url, ac.description, ac.progress_level, ac.requirement_type, ac.requirement_value, 
   0 AS progressCount, 
   false AS completed
FROM achievement_tb AS ac
     LEFT JOIN user_achievement_tb AS uac on uac.achievement_id = ac.id AND uac.user_id = 23
WHERE uac.id IS NULL
AND ac.id IN (
    SELECT min(ac1.id)
    FROM achievement_tb AS ac1
    GROUP BY ac1.activity_type
);
```
![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/729756a7-31ba-4bbe-ac38-8804ffd3fa59)
![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/d518c9a8-32cb-4171-83b7-e2ae1f68f783)
![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/d3c21711-234b-4c8c-8ab5-c4022aec2ef9)



<최적화 이후 코드>
```sql
EXPLAIN
SELECT DISTINCT
    uac.achievement_id, uac.user_id,
    ac.title, ac.img_url, ac.description, ac.progress_level, ac.requirement_type, ac.requirement_value,
    COUNT(distinct uat.created_at) AS progressCount,
    uac.completed
FROM user_achievement_tb AS uac
        INNER JOIN achievement_tb as ac ON uac.achievement_id = ac.id
        INNER JOIN user_activity_tb as uat ON uat.activity_type = ac.activity_type AND uac.user_id = uat.user_id
WHERE uac.user_id = 23 AND ac.requirement_type = 'ACCUMULATE'
GROUP BY uat.activity_type;
```

<img width="872" alt="image" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/bc4f1998-1ac8-4076-bf07-57a0aa406d16">
<img width="965" alt="image" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/294789d0-ec93-43c5-8b32-8c9de4b2b590">
<img width="415" alt="image" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/beab11d0-e956-4d14-a096-054205d50368">

![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/e49db743-ffb6-443c-b1fc-cbf2f5269405)
`평균 15회 기준`

---

```sql
EXPLAIN
SELECT
    ac.id,
    23 AS user_id,
    ac.title, ac.img_url, ac.description, ac.progress_level, ac.requirement_type, ac.requirement_value,
    0 AS progressCount,
    false AS completed
FROM achievement_tb AS ac
        LEFT JOIN user_achievement_tb AS uac ONN uac.achievement_id = ac.id AND uac.user_id = 23
WHERE uac.id IS NULL
AND ac.id IN (
    SELECT MIN(ac1.id)
    FROM achievement_tb AS ac1
    GROUP BY ac1.activity_type
);
```
<img width="871" alt="image" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/07f4dd88-0418-4b72-8c84-14c33067415b">
<img width="871" alt="image" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/020f7672-acf7-4bbc-8e82-992f90f2cc6d">
<img width="268" alt="image" src="https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/71b7d605-8780-4d59-90ad-cc5e31019a99">

![image](https://github.com/Open-Eye-Im-Developer/MoGakGo-BE/assets/57834671/66ded52e-c9ca-4149-a576-0c0884a87408)
`평균 15회 기준`


(추후 테스트 데이터 더미로 인해 10만건이 넘는 데이터 더미를 이용한 테스트도 진행할 예정)
